### PR TITLE
Nablarch JAX-RS用のOpenAPI GeneratorのカスタムGeneratorを実装

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+      <groupId>com.nablarch</groupId>
+      <artifactId>nablarch-parent</artifactId>
+      <version>6u2</version>
+    </parent>
+
+    <groupId>com.nablarch.tool</groupId>
+    <artifactId>nablarch-openapi-generator</artifactId>
+    <packaging>jar</packaging>
+    <name>nablarch-openapi-generator</name>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <scm>
+      <connection>scm:git:git://github.com/nablarch/${project.artifactId}.git</connection>
+      <developerConnection>scm:git:git://github.com/nablarch/${project.artifactId}.git</developerConnection>
+      <url>https://github.com/nablarch/${project.artifactId}/tree/main</url>
+    </scm>
+
+    <properties>
+        <openapi.generator.version>7.10.0</openapi.generator.version>
+        <javaparser.version>3.24.9</javaparser.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>openapi-generator</artifactId>
+            <version>${openapi.generator.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.nablarch.dev</groupId>
+            <artifactId>nablarch-test-support</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.javaparser</groupId>
+            <artifactId>javaparser-core</artifactId>
+            <version>${javaparser.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/main/java/nablarch/tool/openapi/codegen/JavaNablarchJaxrsServerCodegen.java
+++ b/src/main/java/nablarch/tool/openapi/codegen/JavaNablarchJaxrsServerCodegen.java
@@ -1,0 +1,397 @@
+package nablarch.tool.openapi.codegen;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.servers.Server;
+import lombok.Getter;
+import lombok.Setter;
+import org.openapitools.codegen.CliOption;
+import org.openapitools.codegen.CodegenConstants;
+import org.openapitools.codegen.CodegenModel;
+import org.openapitools.codegen.CodegenOperation;
+import org.openapitools.codegen.CodegenProperty;
+import org.openapitools.codegen.languages.AbstractJavaCodegen;
+import org.openapitools.codegen.languages.AbstractJavaJAXRSServerCodegen;
+import org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen;
+
+/**
+ * Nablarch JAX-RS用のOpenAPI GeneratorのカスタムGenerator。
+ * <p>
+ * NablarchのRESTful ウェブサービスはJAX-RSのアノテーションを使用しているため、各種JAX-RSのGeneratorの
+ * 抽象実装である{@link AbstractJavaJAXRSServerCodegen}を拡張して実装する。また、生成する対象はActionが
+ * 実装するAPIのインターフェースとモデル、そして無効化できないサポートファイルのみとする。
+ * <p>
+ * Mustacheテンプレートはjaxrs-specのものをカスタマイズして使用する。
+ *
+ * @see <a href="https://github.com/OpenAPITools/openapi-generator/tree/v7.10.0/modules/openapi-generator/src/main/resources/JavaJaxRS/spec">jaxrs-specのMustacheテンプレート</a>
+ */
+public class JavaNablarchJaxrsServerCodegen extends AbstractJavaJAXRSServerCodegen {
+    /**
+     * Generator前
+     */
+    public static final String GENERATOR_NAME = "nablarch-jaxrs";
+
+    // Generatorのオプション名
+    /**
+     * プリミティブ型のプロパティをすべてString型とする場合のオプション名
+     */
+    static final String PRIMITIVE_PROPERTIES_AS_STRING = "primitivePropertiesAsString";
+
+    /**
+     * サポートするリクエストのメディアタイプのオプション名
+     */
+    static final String SUPPORT_CONSUMES_MEDIA_TYPES = "supportConsumesMediaTypes";
+
+    /**
+     * サポートするレスポンスのメディアタイプのオプション名
+     */
+    static final String SUPPORT_PRODUCES_MEDIA_TYPES = "supportProducesMediaTypes";
+
+    /**
+     * プリミティブ型のプロパティをすべてString型とする場合は{@code true}。
+     */
+    @Getter
+    @Setter
+    private boolean primitivePropertiesAsString = false;
+
+    /**
+     * Generatorがサポートする、リクエストとして受け付けるメディアタイプ。
+     */
+    @Getter
+    @Setter
+    private List<String> supportConsumesMediaTypes = List.of("application/json", "multipart/form-data");
+
+    /**
+     * Generatorがサポートする、レスポンスとして返却するメディアタイプ。
+     */
+    @Getter
+    @Setter
+    private List<String> supportProducesMediaTypes = List.of("application/json");
+
+    /**
+     * Generator名を返却する。
+     *
+     * @return Generator名
+     */
+    public String getName() {
+        return GENERATOR_NAME;
+    }
+
+    /**
+     * ヘルプ（Generatorの簡単な説明）を返却する。
+     *
+     * @return ヘルプ
+     */
+    public String getHelp() {
+        return "Generates a nablarch-jaxrs server library.";
+    }
+
+    /**
+     * コンストラクタ。Generatorのオプションの設定を行う
+     */
+    public JavaNablarchJaxrsServerCodegen() {
+        // set the output folder here
+        outputFolder = "generated-code/nablarch-jaxrs";
+        // GeneratorのMustacheテンプレートの配置先
+        templateDir = "JavaNablarchJaxRs";
+
+        // 継承したクラスから、サポートしないオプションを削除
+        removeOption("title");
+        removeOption("groupId");
+        removeOption("artifactId");
+        removeOption("artifactVersion");
+        removeOption("artifactUrl");
+        removeOption("artifactDescription");
+        removeOption("scmConnection");
+        removeOption("scmDeveloperConnection");
+        removeOption("scmUrl");
+        removeOption("developerName");
+        removeOption("developerEmail");
+        removeOption("developerOrganization");
+        removeOption("developerOrganizationUrl");
+        removeOption("licenseName");
+        removeOption("licenseUrl");
+        removeOption(AbstractJavaCodegen.ADDITIONAL_ONE_OF_TYPE_ANNOTATIONS);
+        removeOption(AbstractJavaCodegen.IMPLICIT_HEADERS);
+        removeOption(AbstractJavaCodegen.IMPLICIT_HEADERS_REGEX);
+        removeOption(AbstractJavaCodegen.OPENAPI_NULLABLE);
+        removeOption(CodegenConstants.PARENT_GROUP_ID);
+        removeOption(CodegenConstants.PARENT_ARTIFACT_ID);
+        removeOption(CodegenConstants.PARENT_VERSION);
+        removeOption(CodegenConstants.SNAPSHOT_VERSION);
+        removeOption(CodegenConstants.LIBRARY);
+        removeOption(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG);
+        removeOption(AbstractJavaJAXRSServerCodegen.SERVER_PORT);
+        removeOption(JavaJAXRSSpecServerCodegen.GENERATE_POM);
+        removeOption(JavaJAXRSSpecServerCodegen.RETURN_RESPONSE);
+        removeOption(JavaJAXRSSpecServerCodegen.USE_SWAGGER_ANNOTATIONS);
+        removeOption(JavaJAXRSSpecServerCodegen.USE_MICROPROFILE_OPENAPI_ANNOTATIONS);
+        removeOption(AbstractJavaCodegen.SUPPORT_ASYNC);
+        removeOption(JavaJAXRSSpecServerCodegen.USE_MUTINY);
+        removeOption(AbstractJavaCodegen.DISABLE_HTML_ESCAPING);
+        removeOption(AbstractJavaCodegen.USE_JAKARTA_EE);
+        removeOption(CodegenConstants.WITH_XML);
+        removeOption(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS);
+        removeOption(CodegenConstants.SERIALIZE_BIG_DECIMAL_AS_STRING);
+        removeOption(AbstractJavaCodegen.BOOLEAN_GETTER_PREFIX);
+        removeOption(AbstractJavaCodegen.CAMEL_CASE_DOLLAR_SIGN);
+        removeOption(AbstractJavaCodegen.CONTAINER_DEFAULT_TO_NULL);
+        removeOption(AbstractJavaCodegen.DATE_LIBRARY);
+        removeOption(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT);
+        removeOption(AbstractJavaCodegen.DISCRIMINATOR_CASE_SENSITIVE);
+        removeOption(CodegenConstants.ENSURE_UNIQUE_PARAMS);
+        removeOption(AbstractJavaCodegen.IGNORE_ANYOF_IN_ENUM);
+        removeOption(CodegenConstants.ENUM_UNKNOWN_DEFAULT_CASE);
+        removeOption(CodegenConstants.INVOKER_PACKAGE);
+        removeOption(CodegenConstants.IMPL_FOLDER);
+        removeOption(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR);
+        removeOption(CodegenConstants.PREPEND_FORM_OR_BODY_PARAMETERS);
+        removeOption(CodegenConstants.SORT_MODEL_PROPERTIES_BY_REQUIRED_FLAG);
+        removeOption(AbstractJavaCodegen.GENERATE_CONSTRUCTOR_WITH_ALL_ARGS);
+        removeOption(AbstractJavaCodegen.TEST_OUTPUT);
+        removeOption(AbstractJavaCodegen.USE_ONE_OF_INTERFACES);
+        removeOption(USE_BEANVALIDATION);
+
+        // デフォルトでBean Validation用のアノテーションは生成しない
+        useBeanValidation = false;
+
+        // オプションのデフォルト値を調整
+        // インターフェースのみの生成とする
+        updateOption(JavaJAXRSSpecServerCodegen.INTERFACE_ONLY, "true");
+        // 生成するコードにSwagger Coreのアノテーションを付与しない
+        updateOption(JavaJAXRSSpecServerCodegen.USE_SWAGGER_ANNOTATIONS, "false");
+        // ヘルプ表示の際にデフォルト値を false に表示するために再設定
+        cliOptions.add(CliOption.newBoolean(USE_BEANVALIDATION, "Use BeanValidation API annotations", useBeanValidation));
+
+        // サポート対象外にしたオプションの値を指定
+        setEnsureUniqueParams(true);
+        setOpenApiNullable(false);
+        setUseJakartaEe(true); // Jakarta EEのみサポート（Java EEはサポートしない）
+        setDateLibrary("java8");  // 日付型はJava 8のDate and Time APIのものを使う
+
+        // 固有のオプションを追加
+        cliOptions.add(CliOption.newBoolean(PRIMITIVE_PROPERTIES_AS_STRING, "Generate all primitive types such as Integer, Long, and Boolean as String types. (default: false)"));
+        cliOptions.add(CliOption.newString(SUPPORT_CONSUMES_MEDIA_TYPES, "Supported consumes media types. List separated by comma(,) or new line (Linux or Windows) (default: application/json)"));
+        cliOptions.add(CliOption.newString(SUPPORT_PRODUCES_MEDIA_TYPES, "Supported produces media types. List separated by comma(,) or new line (Linux or Windows) (default: application/json)"));
+    }
+
+    /**
+     * Generatorに指定されたオプションの処理を行う。
+     */
+    @Override
+    public void processOpts() {
+        super.processOpts();
+
+        convertPropertyToBooleanAndWriteBack(PRIMITIVE_PROPERTIES_AS_STRING, this::setPrimitivePropertiesAsString);
+        convertPropertyToTypeAndWriteBack(
+                SUPPORT_CONSUMES_MEDIA_TYPES,
+                mediaTypes -> Arrays.asList(mediaTypes.trim().split("\\s*(,|\\r?\\n)\\s*")),
+                this::setSupportConsumesMediaTypes
+        );
+        convertPropertyToTypeAndWriteBack(
+                SUPPORT_PRODUCES_MEDIA_TYPES,
+                mediaTypes -> Arrays.asList(mediaTypes.trim().split("\\s*(,|\\r?\\n)\\s*")),
+                this::setSupportProducesMediaTypes
+        );
+
+        // Generatorで生成しないファイルはクリア
+        apiTestTemplateFiles.clear();
+        modelTestTemplateFiles.clear();
+        apiDocTemplateFiles.clear();
+        modelDocTemplateFiles.clear();
+        supportingFiles.clear();
+
+        // import文を追加するための変換表
+        importMapping.put("ExecutionContext", "nablarch.fw.ExecutionContext");
+        importMapping.put("EntityResponse", "nablarch.fw.jaxrs.EntityResponse");
+        importMapping.put("JaxRsHttpRequest", "nablarch.fw.jaxrs.JaxRsHttpRequest");
+        importMapping.put("HttpResponse", "nablarch.fw.web.HttpResponse");
+        importMapping.put("Required", "nablarch.core.validation.ee.Required");
+        importMapping.put("Size", "nablarch.core.validation.ee.Size");
+        importMapping.put("Length", "nablarch.core.validation.ee.Length");
+        importMapping.put("NumberRange", "nablarch.core.validation.ee.NumberRange");
+        importMapping.put("DecimalRange", "nablarch.core.validation.ee.DecimalRange");
+        importMapping.put("Valid", "jakarta.validation.Valid");
+        importMapping.put("Pattern", "jakarta.validation.constraints.Pattern");
+        importMapping.put("Serializable", "java.io.Serializable");
+
+        // Bean Validationのimport文はMustacheテンプレートで制御する
+
+        // プリミティブをすべてStringとして扱う場合
+        if (primitivePropertiesAsString) {
+            typeMapping.put("boolean", "String");
+            typeMapping.put("string", "String");
+            typeMapping.put("int", "String");
+            typeMapping.put("float", "String");
+            typeMapping.put("double", "String");
+            typeMapping.put("number", "String");
+            typeMapping.put("decimal", "String");
+            typeMapping.put("date", "String");
+            typeMapping.put("DateTime", "String");
+            typeMapping.put("long", "String");
+            typeMapping.put("short", "String");
+            typeMapping.put("integer", "String");
+            typeMapping.put("UnsignedInteger", "String");
+            typeMapping.put("UnsignedLong", "String");
+            typeMapping.put("char", "String");
+            typeMapping.put("ByteArray", "String");
+            typeMapping.put("binary", "String");
+            typeMapping.put("file", "String");
+            typeMapping.put("UUID", "String");
+            typeMapping.put("URI", "String");
+            // array、set、map、objectは対象外
+        }
+    }
+
+    /**
+     * オペレーション（エンドポイントに対応するメソッド）の定義からコード生成用のオペレーションを生成する
+     *
+     * @param path       オペレーションのパス
+     * @param httpMethod オペレーションのHTTPメソッド
+     * @param operation  処理対象のオペレーションの定義
+     * @param servers    サーバ
+     * @return コード生成用のオペレーション
+     */
+    @Override
+    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
+        // 継承元から、コード生成用のオペレーションを生成
+        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
+
+        if (op.hasConsumes) {
+            List<Map<String, String>> consumes = op.consumes;
+
+            List<String> unsupportedMediaTypes = new ArrayList<>();
+
+            for (Map<String, String> consume : consumes) {
+                String mediaType = consume.get("mediaType");
+
+                boolean supported = false;
+
+                for (String supportMediaType : supportConsumesMediaTypes) {
+                    if (supportMediaType.equalsIgnoreCase(mediaType)) {
+                        supported = true;
+                        break;
+                    }
+                }
+
+                if (!supported) {
+                    unsupportedMediaTypes.add(mediaType);
+                }
+            }
+
+            if (!unsupportedMediaTypes.isEmpty()) {
+                throw new UnsupportedOperationException("Unsupported consumes media types: " + unsupportedMediaTypes);
+            }
+        }
+
+        if (op.hasProduces) {
+            // レスポンスがバイナリの場合は、サポートするメディアタイプのチェックは行わない
+            if (!op.isResponseBinary) {
+
+                List<Map<String, String>> produces = op.produces;
+
+                List<String> unsupportedMediaTypes = new ArrayList<>();
+
+                for (Map<String, String> consume : produces) {
+                    String mediaType = consume.get("mediaType");
+
+                    boolean supported = false;
+
+                    for (String supportMediaType : supportProducesMediaTypes) {
+                        if (supportMediaType.equalsIgnoreCase(mediaType)) {
+                            supported = true;
+                            break;
+                        }
+                    }
+
+                    if (!supported) {
+                        unsupportedMediaTypes.add(mediaType);
+                    }
+                }
+
+                if (!unsupportedMediaTypes.isEmpty()) {
+                    throw new UnsupportedOperationException("Unsupported produces media types: " + unsupportedMediaTypes);
+                }
+            }
+        }
+
+        // オペレーション（API）に追加するimport
+        op.imports.add("ExecutionContext");
+        op.imports.add("EntityResponse");
+        op.imports.add("JaxRsHttpRequest");
+        op.imports.add("HttpResponse");
+
+        if (isUseBeanValidation()) {
+            // Bean Validationが有効な場合、Apiのimport文に@Validを追加
+            op.imports.add("Valid");
+        }
+
+        return op;
+    }
+
+    /**
+     * モデルに対する後処理
+     *
+     * @param model    コード生成用のモデル
+     * @param property コード生成用のモデルのプロパティ
+     */
+    @Override
+    public void postProcessModelProperty(CodegenModel model, CodegenProperty property) {
+        super.postProcessModelProperty(model, property);
+
+        if (getSerializableModel()) {
+            model.imports.add("Serializable");
+        }
+
+        if (property.isByteArray) {
+            model.imports.add("Arrays");
+        }
+
+        if (isUseBeanValidation()) {
+            model.imports.add("Valid");
+            model.imports.add("Pattern");
+            model.imports.add("Required");
+            model.imports.add("Size");
+            model.imports.add("Length");
+            model.imports.add("NumberRange");
+            model.imports.add("DecimalRange");
+        }
+
+        // モデルから不要なimportを削除
+        model.imports.remove("ApiModel");
+        model.imports.remove("ApiModelProperty");
+    }
+
+    /**
+     * モデル定義から、コード生成用のモデルを生成する
+     *
+     * @param name  モデルの名前
+     * @param model モデル定義
+     * @return コード生成用のモデル
+     */
+    @Override
+    public CodegenModel fromModel(String name, Schema model) {
+        CodegenModel codegenModel = super.fromModel(name, model);
+
+        for (CodegenProperty codegenProperty : codegenModel.allVars) {
+            // モデルが生成されるパターン（非マルチパート）では、string型、binaryフォーマットはサポートしない
+            if (codegenProperty.isBinary) {
+                throw new UnsupportedOperationException("property type: string and format: binary are not supported");
+            }
+        }
+
+        // 必要なimport文を追加
+        codegenModel.imports.add("Arrays");
+
+        // モデルから不要なimportを削除
+        codegenModel.imports.remove("ApiModel");
+
+        return codegenModel;
+    }
+
+}

--- a/src/main/resources/JavaNablarchJaxRs/additionalEnumTypeAnnotations.mustache
+++ b/src/main/resources/JavaNablarchJaxRs/additionalEnumTypeAnnotations.mustache
@@ -1,0 +1,3 @@
+{{#additionalEnumTypeAnnotations}}
+{{{.}}}
+{{/additionalEnumTypeAnnotations}}

--- a/src/main/resources/JavaNablarchJaxRs/additionalModelTypeAnnotations.mustache
+++ b/src/main/resources/JavaNablarchJaxRs/additionalModelTypeAnnotations.mustache
@@ -1,0 +1,3 @@
+{{#additionalModelTypeAnnotations}}
+
+{{{.}}}{{/additionalModelTypeAnnotations}}

--- a/src/main/resources/JavaNablarchJaxRs/api.mustache
+++ b/src/main/resources/JavaNablarchJaxRs/api.mustache
@@ -1,0 +1,18 @@
+package {{package}};
+
+{{#imports}}import {{import}};
+{{/imports}}
+
+import {{javaxPackage}}.ws.rs.*;
+
+@Path("{{commonPath}}"){{#hasConsumes}}
+@Consumes({ {{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}} }){{/hasConsumes}}{{#hasProduces}}
+@Produces({ {{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}} }){{/hasProduces}}
+{{>generatedAnnotation}}
+public interface {{classname}} {
+{{#operations}}
+{{#operation}}
+{{>apiInterface}}
+{{/operation}}
+}
+{{/operations}}

--- a/src/main/resources/JavaNablarchJaxRs/apiInterface.mustache
+++ b/src/main/resources/JavaNablarchJaxRs/apiInterface.mustache
@@ -1,0 +1,20 @@
+    /**
+     * {{httpMethod}} {{{path}}}{{#summary}} : {{.}}{{/summary}}
+     *
+    {{#notes}}
+     * {{.}}
+    {{/notes}}
+     *{{#allParams}}{{#isBodyParam}}
+     * @param {{paramName}} {{description}}{{/isBodyParam}}{{/allParams}}
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     {{#responses}}
+     * @return {{{message}}}
+     {{/responses}}
+     */
+    @{{httpMethod}}{{#subresourceOperation}}
+    @Path("{{{path}}}"){{/subresourceOperation}}{{#hasConsumes}}
+    @Consumes({ {{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}} }){{/hasConsumes}}{{^isResponseBinary}}{{#hasProduces}}
+    @Produces({ {{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}} }){{/hasProduces}}{{/isResponseBinary}}{{#useBeanValidation}}{{#allParams}}{{#isBodyParam}}
+    @Valid{{/isBodyParam}}{{/allParams}}{{/useBeanValidation}}
+    {{#returnProperty}}{{#isResponseBinary}}HttpResponse{{/isResponseBinary}}{{^isResponseBinary}}EntityResponse<{{{dataType}}}>{{/isResponseBinary}}{{/returnProperty}}{{^returnProperty}}HttpResponse{{/returnProperty}} {{operationId}}({{#allParams}}{{#isBodyParam}}{{{dataType}}} {{paramName}}, {{/isBodyParam}}{{/allParams}}JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);

--- a/src/main/resources/JavaNablarchJaxRs/beanValidatedType.mustache
+++ b/src/main/resources/JavaNablarchJaxRs/beanValidatedType.mustache
@@ -1,0 +1,1 @@
+{{#isArray}}{{baseType}}<{{#items}}{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}{{>beanValidatedType}}{{/items}}>{{/isArray}}{{^isArray}}{{{datatypeWithEnum}}}{{/isArray}}

--- a/src/main/resources/JavaNablarchJaxRs/beanValidation.mustache
+++ b/src/main/resources/JavaNablarchJaxRs/beanValidation.mustache
@@ -1,0 +1,3 @@
+{{#required}}{{^isReadOnly}}@Required {{/isReadOnly}}{{/required}}{{!
+}}{{#isContainer}}{{^items.isPrimitiveType}}{{^items.isDate}}{{^items.isDateTime}}{{^items.isString}}{{^items.isFile}}{{^items.isEnumOrRef}}@Valid {{/items.isEnumOrRef}}{{/items.isFile}}{{/items.isString}}{{/items.isDateTime}}{{/items.isDate}}{{/items.isPrimitiveType}}{{/isContainer}}{{^isContainer}}{{^isPrimitiveType}}{{^isDate}}{{^isDateTime}}{{^isString}}{{^isFile}}{{^isEnumOrRef}}@Valid {{/isEnumOrRef}}{{/isFile}}{{/isString}}{{/isDateTime}}{{/isDate}}{{/isPrimitiveType}}{{/isContainer}}{{!
+}}{{>beanValidationCore}}

--- a/src/main/resources/JavaNablarchJaxRs/beanValidationCore.mustache
+++ b/src/main/resources/JavaNablarchJaxRs/beanValidationCore.mustache
@@ -1,0 +1,49 @@
+{{#pattern}}@Pattern(regexp = "{{{.}}}") {{/pattern}}{{!
+  byte array
+}}{{#isByteArray}}{{!
+     minLength && maxLength set
+}}{{#minLength}}{{#maxLength}}@Size(min = {{minLength}}, max = {{maxLength}}) {{/maxLength}}{{/minLength}}{{!
+     minLength set, maxLength not
+}}{{#minLength}}{{^maxLength}}@Size(min = {{minLength}}) {{/maxLength}}{{/minLength}}{{!
+     minLength not set, maxLength set
+}}{{^minLength}}{{#maxLength}}@Size(max = {{.}}) {{/maxLength}}{{/minLength}}{{!
+}}{{/isByteArray}}{{^isByteArray}}{{!
+  not byte array(string)
+}}{{!
+     minLength && maxLength set
+}}{{#minLength}}{{#maxLength}}@Length(min = {{minLength}}, max = {{maxLength}}) {{/maxLength}}{{/minLength}}{{!
+     minLength set, maxLength not
+}}{{#minLength}}{{^maxLength}}@Length(min = {{minLength}}) {{/maxLength}}{{/minLength}}{{!
+     minLength not set, maxLength set
+}}{{^minLength}}{{#maxLength}}@Length(max = {{.}}) {{/maxLength}}{{/minLength}}{{!
+}}{{/isByteArray}}{{!
+@Size: minItems && maxItems set
+}}{{#minItems}}{{#maxItems}}@Size(min = {{minItems}}, max = {{maxItems}}) {{/maxItems}}{{/minItems}}{{!
+@Size: minItems set, maxItems not
+}}{{#minItems}}{{^maxItems}}@Size(min = {{minItems}}) {{/maxItems}}{{/minItems}}{{!
+@Size: minItems not set && maxItems set
+}}{{^minItems}}{{#maxItems}}@Size(max = {{.}}) {{/maxItems}}{{/minItems}}{{!
+  integer
+}}{{#isInteger}}{{!
+     minimum && maximum set
+}}{{#minimum}}{{#maximum}}@NumberRange(min = {{minimum}}, max = {{maximum}}) {{/maximum}}{{/minimum}}{{!
+     minimum set && maximum not set
+}}{{#minimum}}{{^maximum}}@NumberRange(min = {{minimum}}) {{/maximum}}{{/minimum}}{{!
+     minimum not set && maximum set
+}}{{^minimum}}{{#maximum}}@NumberRange(max = {{maximum}}) {{/maximum}}{{/minimum}}{{/isInteger}}{{!
+  long
+}}{{#isLong}}{{!
+     minimum && maximum set
+}}{{#minimum}}{{#maximum}}@NumberRange(min = {{minimum}}, max = {{maximum}}) {{/maximum}}{{/minimum}}{{!
+     minimum set && maximum not set
+}}{{#minimum}}{{^maximum}}@NumberRange(min = {{minimum}}) {{/maximum}}{{/minimum}}{{!
+     minimum not set && maximum set
+}}{{^minimum}}{{#maximum}}@NumberRange(max = {{maximum}}) {{/maximum}}{{/minimum}}{{/isLong}}{{!
+Not Integer, not Long => we have a decimal value!
+}}{{^isInteger}}{{^isLong}}{{!
+     minimum && maximum set
+}}{{#minimum}}{{#maximum}}@DecimalRange(min = "{{minimum}}", max = "{{maximum}}") {{/maximum}}{{/minimum}}{{!
+     minimum set && maximum not set
+}}{{#minimum}}{{^maximum}}@DecimalRange(min = "{{minimum}}") {{/maximum}}{{/minimum}}{{!
+     minimum not set && maximum set
+}}{{^minimum}}{{#maximum}}@DecimalRange(max = "{{maximum}}") {{/maximum}}{{/minimum}}{{/isLong}}{{/isInteger}}

--- a/src/main/resources/JavaNablarchJaxRs/enumClass.mustache
+++ b/src/main/resources/JavaNablarchJaxRs/enumClass.mustache
@@ -1,0 +1,33 @@
+{{>additionalEnumTypeAnnotations}}public enum {{datatypeWithEnum}} {
+
+    {{#allowableValues}}
+    {{#enumVars}}{{name}}({{dataType}}.valueOf({{{value}}})){{^-last}}, {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}
+    {{/allowableValues}}
+
+
+    private {{dataType}} value;
+
+    {{datatypeWithEnum}} ({{dataType}} v) {
+        value = v;
+    }
+
+    public {{dataType}} value() {
+        return value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static {{datatypeWithEnum}} fromValue({{dataType}} value) {
+        for ({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
+            if (b.value.{{^isString}}equals{{/isString}}{{#isString}}{{#useEnumCaseInsensitive}}equalsIgnoreCase{{/useEnumCaseInsensitive}}{{^useEnumCaseInsensitive}}equals{{/useEnumCaseInsensitive}}{{/isString}}(value)) {
+                return b;
+            }
+        }
+        {{#isNullable}}return null;{{/isNullable}}{{^isNullable}}{{#enumUnknownDefaultCase}}{{#allowableValues}}{{#enumVars}}{{#-last}}return {{{name}}};{{/-last}}{{/enumVars}}{{/allowableValues}}{{/enumUnknownDefaultCase}}{{^enumUnknownDefaultCase}}throw new IllegalArgumentException("Unexpected value '" + value + "'");{{/enumUnknownDefaultCase}}{{/isNullable}}
+    }
+}

--- a/src/main/resources/JavaNablarchJaxRs/generatedAnnotation.mustache
+++ b/src/main/resources/JavaNablarchJaxRs/generatedAnnotation.mustache
@@ -1,0 +1,1 @@
+@{{javaxPackage}}.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}}, comments = "Generator version: {{generatorVersion}}")

--- a/src/main/resources/JavaNablarchJaxRs/model.mustache
+++ b/src/main/resources/JavaNablarchJaxRs/model.mustache
@@ -1,0 +1,13 @@
+package {{package}};
+
+{{#imports}}import {{import}};
+{{/imports}}
+
+{{#models}}
+{{#model}}
+{{#isEnum}}
+{{>enumOuterClass}}
+{{/isEnum}}
+{{^isEnum}}{{>pojo}}{{/isEnum}}
+{{/model}}
+{{/models}}

--- a/src/main/resources/JavaNablarchJaxRs/pojo.mustache
+++ b/src/main/resources/JavaNablarchJaxRs/pojo.mustache
@@ -1,0 +1,195 @@
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{#description}}/**
+ * {{.}}
+ */{{/description}}
+@JsonTypeName("{{name}}")
+{{>generatedAnnotation}}{{>additionalModelTypeAnnotations}}
+{{#vendorExtensions.x-class-extra-annotation}}
+{{{vendorExtensions.x-class-extra-annotation}}}
+{{/vendorExtensions.x-class-extra-annotation}}
+public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
+  {{#vars}}
+  {{#isEnum}}
+  {{^isContainer}}
+  {{>enumClass}}
+  {{/isContainer}}
+  {{#isContainer}}
+  {{#mostInnerItems}}
+  {{>enumClass}}
+  {{/mostInnerItems}}
+  {{/isContainer}}
+  {{/isEnum}}
+  {{#vendorExtensions.x-field-extra-annotation}}
+  {{{vendorExtensions.x-field-extra-annotation}}}
+  {{/vendorExtensions.x-field-extra-annotation}}
+  private {{#isContainer}}{{#useBeanValidation}}@Valid {{/useBeanValidation}}{{/isContainer}}{{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
+  {{/vars}}
+  {{#generateBuilders}}
+  {{^additionalProperties}}
+
+    protected {{classname}}({{classname}}Builder<?, ?> b) {
+    {{#parent}}
+        super(b);
+    {{/parent}}
+    {{#vars}}
+        this.{{name}} = b.{{name}};
+    {{/vars}}
+    }
+
+    public {{classname}}() {
+    }
+  {{/additionalProperties}}
+  {{/generateBuilders}}
+
+  {{#vars}}
+    /**
+   {{#description}}
+     * {{.}}
+   {{/description}}
+   {{#minimum}}
+     * minimum: {{.}}
+   {{/minimum}}
+   {{#maximum}}
+     * maximum: {{.}}
+   {{/maximum}}
+     */
+    public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
+        this.{{name}} = {{name}};
+        return this;
+    }
+
+    {{#vendorExtensions.x-extra-annotation}}{{{vendorExtensions.x-extra-annotation}}}{{/vendorExtensions.x-extra-annotation}}
+    @JsonProperty("{{baseName}}")
+{{#useBeanValidation}}
+    {{>beanValidation}}
+{{/useBeanValidation}}
+    public {{>beanValidatedType}} {{getter}}() {
+        return {{name}};
+    }
+
+    @JsonProperty("{{baseName}}")
+    {{#vendorExtensions.x-setter-extra-annotation}}{{{vendorExtensions.x-setter-extra-annotation}}}
+    {{/vendorExtensions.x-setter-extra-annotation}}public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
+        this.{{name}} = {{name}};
+    }
+
+    {{#isArray}}
+    public {{classname}} add{{nameInPascalCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
+        if (this.{{name}} == null) {
+            this.{{name}} = {{{defaultValue}}}{{^defaultValue}}new {{#uniqueItems}}LinkedHashSet{{/uniqueItems}}{{^uniqueItems}}ArrayList{{/uniqueItems}}<>(){{/defaultValue}};
+        }
+
+        this.{{name}}.add({{name}}Item);
+        return this;
+    }
+
+    public {{classname}} remove{{nameInPascalCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
+        if ({{name}}Item != null && this.{{name}} != null) {
+            this.{{name}}.remove({{name}}Item);
+        }
+
+        return this;
+    }
+  {{/isArray}}
+  {{#isMap}}
+    public {{classname}} put{{nameInPascalCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
+        if (this.{{name}} == null) {
+            this.{{name}} = {{{defaultValue}}}{{^defaultValue}}new HashMap<>(){{/defaultValue}};
+        }
+
+        this.{{name}}.put(key, {{name}}Item);
+        return this;
+    }
+
+    public {{classname}} remove{{nameInPascalCase}}Item(String key) {
+        if (this.{{name}} != null) {
+            this.{{name}}.remove(key);
+        }
+
+        return this;
+    }
+  {{/isMap}}
+  {{/vars}}
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }{{#hasVars}}
+        {{classname}} {{classVarName}} = ({{classname}}) o;
+        return {{#vars}}{{#isByteArray}}Arrays{{/isByteArray}}{{^isByteArray}}Objects{{/isByteArray}}.equals(this.{{name}}, {{classVarName}}.{{name}}){{^-last}} &&
+            {{/-last}}{{/vars}}{{#parent}} &&
+            super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
+        return {{#parent}}super.equals(o){{/parent}}{{^parent}}true{{/parent}};{{/hasVars}}
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash({{#vars}}{{^isByteArray}}{{name}}{{/isByteArray}}{{#isByteArray}}Arrays.hashCode({{name}}){{/isByteArray}}{{^-last}}, {{/-last}}{{/vars}}{{#parent}}{{#hasVars}}, {{/hasVars}}super.hashCode(){{/parent}});
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class {{classname}} {\n");
+        {{#parent}}sb.append("    ").append(toIndentedString(super.toString())).append("\n");{{/parent}}
+        {{#vars}}sb.append("    {{name}}: ").append({{#isPassword}}"*"{{/isPassword}}{{^isPassword}}toIndentedString({{name}}){{/isPassword}}).append("\n");
+        {{/vars}}sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+{{#generateBuilders}}{{^additionalProperties}}
+    public static {{classname}}Builder<?, ?> builder() {
+        return new {{classname}}BuilderImpl();
+    }
+
+    private static class {{classname}}BuilderImpl extends {{classname}}Builder<{{classname}}, {{classname}}BuilderImpl> {
+
+    @Override
+    protected {{classname}}BuilderImpl self() {
+        return this;
+    }
+
+    @Override
+    public {{classname}} build() {
+        return new {{classname}}(this);
+    }
+  }
+
+    public static abstract class {{classname}}Builder<C extends {{classname}}, B extends {{classname}}Builder<C, B>> {{#parent}}extends {{{.}}}Builder<C, B>{{/parent}} {
+    {{#vars}}
+        private {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
+    {{/vars}}
+  {{^parent}}
+        protected abstract B self();
+
+        public abstract C build();
+    {{/parent}}
+
+    {{#vars}}
+        public B {{name}}({{{datatypeWithEnum}}} {{name}}) {
+            this.{{name}} = {{name}};
+            return self();
+        }
+    {{/vars}}
+    }{{/additionalProperties}}{{/generateBuilders}}
+}

--- a/src/main/resources/JavaNablarchJaxRs/returnTypeInterface.mustache
+++ b/src/main/resources/JavaNablarchJaxRs/returnTypeInterface.mustache
@@ -1,0 +1,1 @@
+{{dataType}}

--- a/src/main/resources/JavaNablarchJaxRs/typeInfoAnnotation.mustache
+++ b/src/main/resources/JavaNablarchJaxRs/typeInfoAnnotation.mustache
@@ -1,0 +1,8 @@
+{{#jackson}}
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "{{{discriminator.propertyBaseName}}}", visible = true)
+@JsonSubTypes({
+  {{#discriminator.mappedModels}}
+  @JsonSubTypes.Type(value = {{modelName}}.class, name = "{{^vendorExtensions.x-discriminator-value}}{{mappingName}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}"),
+  {{/discriminator.mappedModels}}
+})
+{{/jackson}}

--- a/src/main/resources/META-INF/services/org.openapitools.codegen.CodegenConfig
+++ b/src/main/resources/META-INF/services/org.openapitools.codegen.CodegenConfig
@@ -1,0 +1,1 @@
+nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen

--- a/src/test/java/nablarch/tool/openapi/codegen/CodegenOptionsTest.java
+++ b/src/test/java/nablarch/tool/openapi/codegen/CodegenOptionsTest.java
@@ -1,0 +1,956 @@
+package nablarch.tool.openapi.codegen;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import nablarch.tool.openapi.codegen.test.GeneratorAssertions;
+import nablarch.tool.openapi.codegen.test.JavaNablarchJaxrsServerCodegenOpenApi30TestSupport;
+import org.junit.Test;
+import org.openapitools.codegen.ClientOptInput;
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.config.CodegenConfigurator;
+
+/**
+ * {@link JavaNablarchJaxrsServerCodegen}でサポートするオプションをテストするクラス。
+ */
+public class CodegenOptionsTest extends JavaNablarchJaxrsServerCodegenOpenApi30TestSupport {
+    /**
+     * ヘルプメッセージの確認
+     */
+    @Test
+    public void help() {
+        JavaNablarchJaxrsServerCodegen codegen = new JavaNablarchJaxrsServerCodegen();
+        assertEquals("Generates a nablarch-jaxrs server library.", codegen.getHelp());
+    }
+
+    /**
+     * デフォルトのオプションで実行して生成結果を確認する
+     */
+    @Test
+    public void defaultOptions() {
+        Map<String, Object> properties = new HashMap<>();
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("projects.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> generatedFiles = generator.opts(clientOptInput).generate();
+
+        String[] expectedGenerateFiles = {
+                // パッケージはデフォルト
+                "src/gen/java/org/openapitools/api/ProjectsApi.java",
+                "src/gen/java/org/openapitools/api/UsersApi.java",
+                "src/gen/java/org/openapitools/model/ProjectRequest.java",
+                "src/gen/java/org/openapitools/model/ProjectResponse.java",
+                "src/gen/java/org/openapitools/model/Client.java",
+                "src/gen/java/org/openapitools/model/UserRequest.java",
+                "src/gen/java/org/openapitools/model/UserResponse.java",
+                "src/gen/java/org/openapitools/model/ErrorResponse.java"
+        };
+
+        // 生成されたファイルが存在することを確認
+        GeneratorAssertions.assertExistsFiles(
+                output,
+                generatedFiles,
+                mergeSupportFilesDocumentSpecifiedFiles(expectedGenerateFiles)
+        );
+        // 生成されたJavaソースコードが正しい構文であることを確認
+        GeneratorAssertions.assertValidJavaSourceSyntax(generatedFiles);
+
+        // サポートファイルを除いた生成されたファイルのリストを作成
+        List<File> generatedFilesExcludeSupportFiles = excludeSupportFiles(generatedFiles);
+
+        // 生成されたファイルと期待値を比較して、内容が一致することを確認
+        for (File generateFile : generatedFilesExcludeSupportFiles) {
+            GeneratorAssertions.assertEqualsFileContents(
+                    generateFile,
+                    getExpectedResourceFile(output, generateFile),
+                    IGNORE_GENERATED_ANNOTATION_PATTERN
+            );
+        }
+    }
+
+    /**
+     * APIとモデルの出力先パッケージを指定
+     */
+    @Test
+    public void apiAndModelPackage() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("apiPackage", "com.example.someservice.api");
+        properties.put("modelPackage", "org.example.testservice.model");
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("projects.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> generatedFiles = generator.opts(clientOptInput).generate();
+
+        String[] expectedGenerateFiles = {
+                // APIのパッケージが変更されている
+                "src/gen/java/com/example/someservice/api/ProjectsApi.java",
+                "src/gen/java/com/example/someservice/api/UsersApi.java",
+                // モデルのパッケージが変更されている
+                "src/gen/java/org/example/testservice/model/ProjectRequest.java",
+                "src/gen/java/org/example/testservice/model/ProjectResponse.java",
+                "src/gen/java/org/example/testservice/model/Client.java",
+                "src/gen/java/org/example/testservice/model/UserRequest.java",
+                "src/gen/java/org/example/testservice/model/UserResponse.java",
+                "src/gen/java/org/example/testservice/model/ErrorResponse.java"
+        };
+
+        // 生成されたファイルが存在することを確認
+        GeneratorAssertions.assertExistsFiles(
+                output,
+                generatedFiles,
+                mergeSupportFilesDocumentSpecifiedFiles(expectedGenerateFiles)
+        );
+        // 生成されたJavaソースコードが正しい構文であることを確認
+        GeneratorAssertions.assertValidJavaSourceSyntax(generatedFiles);
+
+        // サポートファイルを除いた生成されたファイルのリストを作成
+        List<File> generatedFilesExcludeSupportFiles = excludeSupportFiles(generatedFiles);
+
+        // 生成されたファイルと期待値を比較して、内容が一致することを確認
+        for (File generateFile : generatedFilesExcludeSupportFiles) {
+            GeneratorAssertions.assertEqualsFileContents(
+                    generateFile,
+                    getExpectedResourceFile(output, generateFile),
+                    IGNORE_GENERATED_ANNOTATION_PATTERN
+            );
+        }
+    }
+
+    /**
+     * {@code @Generated}の{@code date}属性（生成日時）の出力を抑制
+     */
+    @Test
+    public void hideGenerationTimestamp() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("hideGenerationTimestamp", true);
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("projects.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> generatedFiles = generator.opts(clientOptInput).generate();
+
+        String[] expectedGenerateFiles = {
+                "src/gen/java/org/openapitools/api/ProjectsApi.java",
+                "src/gen/java/org/openapitools/api/UsersApi.java",
+                "src/gen/java/org/openapitools/model/ProjectRequest.java",
+                "src/gen/java/org/openapitools/model/ProjectResponse.java",
+                "src/gen/java/org/openapitools/model/Client.java",
+                "src/gen/java/org/openapitools/model/UserRequest.java",
+                "src/gen/java/org/openapitools/model/UserResponse.java",
+                "src/gen/java/org/openapitools/model/ErrorResponse.java"
+        };
+
+        // 生成されたファイルが存在することを確認
+        GeneratorAssertions.assertExistsFiles(
+                output,
+                generatedFiles,
+                mergeSupportFilesDocumentSpecifiedFiles(expectedGenerateFiles)
+        );
+        // 生成されたJavaソースコードが正しい構文であることを確認
+        GeneratorAssertions.assertValidJavaSourceSyntax(generatedFiles);
+
+        // サポートファイルを除いた生成されたファイルのリストを作成
+        List<File> generatedFilesExcludeSupportFiles = excludeSupportFiles(generatedFiles);
+
+        // 生成されたファイルと期待値を比較して、内容が一致することを確認
+        for (File generateFile : generatedFilesExcludeSupportFiles) {
+            GeneratorAssertions.assertEqualsFileContents(
+                    generateFile,
+                    getExpectedResourceFile(output, generateFile),
+                    IGNORE_GENERATED_ANNOTATION_PATTERN
+            );
+
+            GeneratorAssertions.assertNotContainsPatterns(
+                    generateFile,
+                    // @Generatedのdate属性は出力されなくなる
+                    "^@jakarta\\.annotation\\.Generated\\(.+ date = \".+\".+, .+"
+            );
+        }
+    }
+
+    /**
+     * 出力先のフォルダを指定
+     */
+    @Test
+    public void sourceFolder() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("sourceFolder", "src/oai-gen/main/java");
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("projects.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> generatedFiles = generator.opts(clientOptInput).generate();
+
+        String[] expectedGenerateFiles = {
+                // パッケージはデフォルトで、出力先のフォルダが変更されている
+                "src/oai-gen/main/java/org/openapitools/api/ProjectsApi.java",
+                "src/oai-gen/main/java/org/openapitools/api/UsersApi.java",
+                "src/oai-gen/main/java/org/openapitools/model/ProjectRequest.java",
+                "src/oai-gen/main/java/org/openapitools/model/ProjectResponse.java",
+                "src/oai-gen/main/java/org/openapitools/model/Client.java",
+                "src/oai-gen/main/java/org/openapitools/model/UserRequest.java",
+                "src/oai-gen/main/java/org/openapitools/model/UserResponse.java",
+                "src/oai-gen/main/java/org/openapitools/model/ErrorResponse.java"
+        };
+
+        // 生成されたファイルが存在することを確認
+        GeneratorAssertions.assertExistsFiles(
+                output,
+                generatedFiles,
+                mergeSupportFilesDocumentSpecifiedFiles(expectedGenerateFiles)
+        );
+        // 生成されたJavaソースコードが正しい構文であることを確認
+        GeneratorAssertions.assertValidJavaSourceSyntax(generatedFiles);
+
+        // サポートファイルを除いた生成されたファイルのリストを作成
+        List<File> generatedFilesExcludeSupportFiles = excludeSupportFiles(generatedFiles);
+
+        // 生成されたファイルと期待値を比較して、内容が一致することを確認
+        for (File generateFile : generatedFilesExcludeSupportFiles) {
+            GeneratorAssertions.assertEqualsFileContents(
+                    generateFile,
+                    getExpectedResourceFile(output, generateFile),
+                    IGNORE_GENERATED_ANNOTATION_PATTERN
+            );
+        }
+    }
+
+    /**
+     * Apiの生成単位をパスではなくタグにする
+     */
+    @Test
+    public void useTags() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("useTags", true);
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("projects.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> generatedFiles = generator.opts(clientOptInput).generate();
+
+        String[] expectedGenerateFiles = {
+                // 生成されるApiがタグで分かれるようになる
+                "src/gen/java/org/openapitools/api/ProjectReadApi.java",
+                "src/gen/java/org/openapitools/api/ProjectWriteApi.java",
+                "src/gen/java/org/openapitools/api/ClientReadApi.java",
+                "src/gen/java/org/openapitools/api/UserReadApi.java",
+                "src/gen/java/org/openapitools/api/UserWriteApi.java",
+                // モデルは変化なし
+                "src/gen/java/org/openapitools/model/ProjectRequest.java",
+                "src/gen/java/org/openapitools/model/ProjectResponse.java",
+                "src/gen/java/org/openapitools/model/Client.java",
+                "src/gen/java/org/openapitools/model/UserRequest.java",
+                "src/gen/java/org/openapitools/model/UserResponse.java",
+                "src/gen/java/org/openapitools/model/ErrorResponse.java"
+        };
+
+        // 生成されたファイルが存在することを確認
+        GeneratorAssertions.assertExistsFiles(
+                output,
+                generatedFiles,
+                mergeSupportFilesDocumentSpecifiedFiles(expectedGenerateFiles)
+        );
+        // 生成されたJavaソースコードが正しい構文であることを確認
+        GeneratorAssertions.assertValidJavaSourceSyntax(generatedFiles);
+
+        // サポートファイルを除いた生成されたファイルのリストを作成
+        List<File> generatedFilesExcludeSupportFiles = excludeSupportFiles(generatedFiles);
+
+        // 生成されたファイルと期待値を比較して、内容が一致することを確認
+        for (File generateFile : generatedFilesExcludeSupportFiles) {
+            GeneratorAssertions.assertEqualsFileContents(
+                    generateFile,
+                    getExpectedResourceFile(output, generateFile),
+                    IGNORE_GENERATED_ANNOTATION_PATTERN
+            );
+        }
+    }
+
+    /**
+     * Apiの生成単位をパスではなくタグにする。エンドポイントには複数のタグを付与している
+     */
+    @Test
+    public void useTagsForMultipleTag() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("useTags", true);
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("projects_multiple_tags.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> generatedFiles = generator.opts(clientOptInput).generate();
+
+        String[] expectedGenerateFiles = {
+                // 生成されるApiがタグで分かれるようになり、最初に付与したタグでまとめられる
+                "src/gen/java/org/openapitools/api/ReadApi.java",
+                "src/gen/java/org/openapitools/api/WriteApi.java",
+                // モデルは変化なし
+                "src/gen/java/org/openapitools/model/ProjectRequest.java",
+                "src/gen/java/org/openapitools/model/ProjectResponse.java",
+                "src/gen/java/org/openapitools/model/Client.java",
+                "src/gen/java/org/openapitools/model/UserRequest.java",
+                "src/gen/java/org/openapitools/model/UserResponse.java",
+                "src/gen/java/org/openapitools/model/ErrorResponse.java"
+        };
+
+        // 生成されたファイルが存在することを確認
+        GeneratorAssertions.assertExistsFiles(
+                output,
+                generatedFiles,
+                mergeSupportFilesDocumentSpecifiedFiles(expectedGenerateFiles)
+        );
+        // 生成されたJavaソースコードが正しい構文であることを確認
+        GeneratorAssertions.assertValidJavaSourceSyntax(generatedFiles);
+
+        // サポートファイルを除いた生成されたファイルのリストを作成
+        List<File> generatedFilesExcludeSupportFiles = excludeSupportFiles(generatedFiles);
+
+        // 生成されたファイルと期待値を比較して、内容が一致することを確認
+        for (File generateFile : generatedFilesExcludeSupportFiles) {
+            GeneratorAssertions.assertEqualsFileContents(
+                    generateFile,
+                    getExpectedResourceFile(output, generateFile),
+                    IGNORE_GENERATED_ANNOTATION_PATTERN
+            );
+        }
+    }
+
+    /**
+     * モデルにSerializableインターフェースを実装する。
+     */
+    @Test
+    public void serializableModel() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("serializableModel", true);
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("projects.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> generatedFiles = generator.opts(clientOptInput).generate();
+
+        String[] expectedGenerateFiles = {
+                "src/gen/java/org/openapitools/api/ProjectsApi.java",
+                "src/gen/java/org/openapitools/api/UsersApi.java",
+                "src/gen/java/org/openapitools/model/ProjectRequest.java",
+                "src/gen/java/org/openapitools/model/ProjectResponse.java",
+                "src/gen/java/org/openapitools/model/Client.java",
+                "src/gen/java/org/openapitools/model/UserRequest.java",
+                "src/gen/java/org/openapitools/model/UserResponse.java",
+                "src/gen/java/org/openapitools/model/ErrorResponse.java"
+        };
+
+        // 生成されたファイルが存在することを確認
+        GeneratorAssertions.assertExistsFiles(
+                output,
+                generatedFiles,
+                mergeSupportFilesDocumentSpecifiedFiles(expectedGenerateFiles)
+        );
+        // 生成されたJavaソースコードが正しい構文であることを確認
+        GeneratorAssertions.assertValidJavaSourceSyntax(generatedFiles);
+
+        // サポートファイルを除いた生成されたファイルのリストを作成
+        List<File> generatedFilesExcludeSupportFiles = excludeSupportFiles(generatedFiles);
+
+        // 生成されたファイルと期待値を比較して、内容が一致することを確認
+        for (File generateFile : generatedFilesExcludeSupportFiles) {
+            GeneratorAssertions.assertEqualsFileContents(
+                    generateFile,
+                    getExpectedResourceFile(output, generateFile),
+                    IGNORE_GENERATED_ANNOTATION_PATTERN
+            );
+        }
+
+        // モデルにSerializableインターフェースが実装されていることを確認
+        List<File> generatedModelFiles = filterModelFiles(generatedFiles, "src/gen/java/org/openapitools/model");
+
+        for (File generatedModelFile : generatedModelFiles) {
+            GeneratorAssertions.assertContainsPatterns(
+                    generatedModelFile,
+                    "^import java\\.io\\.Serializable;",
+                    ".*implements Serializable"
+            );
+        }
+    }
+
+    /**
+     * モデルにビルダーを生成する
+     */
+    @Test
+    public void generateBuilders() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("generateBuilders", true);
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("projects.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> generatedFiles = generator.opts(clientOptInput).generate();
+
+        String[] expectedGenerateFiles = {
+                "src/gen/java/org/openapitools/api/ProjectsApi.java",
+                "src/gen/java/org/openapitools/api/UsersApi.java",
+                "src/gen/java/org/openapitools/model/ProjectRequest.java",
+                "src/gen/java/org/openapitools/model/ProjectResponse.java",
+                "src/gen/java/org/openapitools/model/Client.java",
+                "src/gen/java/org/openapitools/model/UserRequest.java",
+                "src/gen/java/org/openapitools/model/UserResponse.java",
+                "src/gen/java/org/openapitools/model/ErrorResponse.java"
+        };
+
+        // 生成されたファイルが存在することを確認
+        GeneratorAssertions.assertExistsFiles(
+                output,
+                generatedFiles,
+                mergeSupportFilesDocumentSpecifiedFiles(expectedGenerateFiles)
+        );
+        // 生成されたJavaソースコードが正しい構文であることを確認
+        GeneratorAssertions.assertValidJavaSourceSyntax(generatedFiles);
+
+        // サポートファイルを除いた生成されたファイルのリストを作成
+        List<File> generatedFilesExcludeSupportFiles = excludeSupportFiles(generatedFiles);
+
+        // 生成されたファイルと期待値を比較して、内容が一致することを確認
+        for (File generateFile : generatedFilesExcludeSupportFiles) {
+            GeneratorAssertions.assertEqualsFileContents(
+                    generateFile,
+                    getExpectedResourceFile(output, generateFile),
+                    IGNORE_GENERATED_ANNOTATION_PATTERN
+            );
+        }
+
+        // モデルにビルダーが生成されていることを確認
+        List<File> generatedModelFiles = filterModelFiles(generatedFiles, "src/gen/java/org/openapitools/model");
+
+        for (File generatedModelFile : generatedModelFiles) {
+            GeneratorAssertions.assertContainsPatterns(
+                    generatedModelFile,
+                    "\\s+private static class .+BuilderImpl extends .+Builder"
+            );
+        }
+    }
+
+    /**
+     * Bean Validationを有効にする
+     */
+    @Test
+    public void useBeanValidation() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("useBeanValidation", true);
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("projects.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> generatedFiles = generator.opts(clientOptInput).generate();
+
+        String[] expectedGenerateFiles = {
+                "src/gen/java/org/openapitools/api/ProjectsApi.java",
+                "src/gen/java/org/openapitools/api/UsersApi.java",
+                "src/gen/java/org/openapitools/model/ProjectRequest.java",
+                "src/gen/java/org/openapitools/model/ProjectResponse.java",
+                "src/gen/java/org/openapitools/model/Client.java",
+                "src/gen/java/org/openapitools/model/UserRequest.java",
+                "src/gen/java/org/openapitools/model/UserResponse.java",
+                "src/gen/java/org/openapitools/model/ErrorResponse.java"
+        };
+
+        // 生成されたファイルが存在することを確認
+        GeneratorAssertions.assertExistsFiles(
+                output,
+                generatedFiles,
+                mergeSupportFilesDocumentSpecifiedFiles(expectedGenerateFiles)
+        );
+        // 生成されたJavaソースコードが正しい構文であることを確認
+        GeneratorAssertions.assertValidJavaSourceSyntax(generatedFiles);
+
+        // サポートファイルを除いた生成されたファイルのリストを作成
+        List<File> generatedFilesExcludeSupportFiles = excludeSupportFiles(generatedFiles);
+
+        // 生成されたファイルと期待値を比較して、内容が一致することを確認
+        for (File generateFile : generatedFilesExcludeSupportFiles) {
+            GeneratorAssertions.assertEqualsFileContents(
+                    generateFile,
+                    getExpectedResourceFile(output, generateFile),
+                    IGNORE_GENERATED_ANNOTATION_PATTERN
+            );
+        }
+
+        // Apiに@Validアノテーションが使用されていることを確認
+        List<File> generatedApiFiles = filterApiFiles(generatedFiles, "src/gen/java/org/openapitools/api");
+
+        for (File generatedApiFile : generatedApiFiles) {
+            GeneratorAssertions.assertContainsPatterns(
+                    generatedApiFile,
+                    "^import jakarta.validation.Valid;"
+            );
+        }
+
+        // モデルにBean Validationのアノテーションが使用されていることを確認
+        List<File> generatedModelFiles = filterModelFiles(generatedFiles, "src/gen/java/org/openapitools/model");
+
+        for (File generatedModelFile : generatedModelFiles) {
+            GeneratorAssertions.assertContainsPatterns(
+                    generatedModelFile,
+                    "^import jakarta.validation.constraints",
+                    "^import nablarch.core.validation.ee"
+            );
+        }
+    }
+
+    /**
+     * モデルに追加のアノテーションを付与する
+     */
+    @Test
+    public void additionalModelTypeAnnotations() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("additionalModelTypeAnnotations", "@jakarta.enterprise.context.SessionScoped;@jakarta.enterprise.context.RequestScoped;");
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("projects.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> generatedFiles = generator.opts(clientOptInput).generate();
+
+        String[] expectedGenerateFiles = {
+                "src/gen/java/org/openapitools/api/ProjectsApi.java",
+                "src/gen/java/org/openapitools/api/UsersApi.java",
+                "src/gen/java/org/openapitools/model/ProjectRequest.java",
+                "src/gen/java/org/openapitools/model/ProjectResponse.java",
+                "src/gen/java/org/openapitools/model/Client.java",
+                "src/gen/java/org/openapitools/model/UserRequest.java",
+                "src/gen/java/org/openapitools/model/UserResponse.java",
+                "src/gen/java/org/openapitools/model/ErrorResponse.java"
+        };
+
+        // 生成されたファイルが存在することを確認
+        GeneratorAssertions.assertExistsFiles(
+                output,
+                generatedFiles,
+                mergeSupportFilesDocumentSpecifiedFiles(expectedGenerateFiles)
+        );
+        // 生成されたJavaソースコードが正しい構文であることを確認
+        GeneratorAssertions.assertValidJavaSourceSyntax(generatedFiles);
+
+        // サポートファイルを除いた生成されたファイルのリストを作成
+        List<File> generatedFilesExcludeSupportFiles = excludeSupportFiles(generatedFiles);
+
+        // 生成されたファイルと期待値を比較して、内容が一致することを確認
+        for (File generateFile : generatedFilesExcludeSupportFiles) {
+            GeneratorAssertions.assertEqualsFileContents(
+                    generateFile,
+                    getExpectedResourceFile(output, generateFile),
+                    IGNORE_GENERATED_ANNOTATION_PATTERN
+            );
+        }
+
+        // モデルに追加のアノテーションが付与されていることを確認
+        List<File> generatedModelFiles = filterModelFiles(generatedFiles, "src/gen/java/org/openapitools/model");
+
+        for (File generatedModelFile : generatedModelFiles) {
+            GeneratorAssertions.assertContainsPatterns(
+                    generatedModelFile,
+                    "^@jakarta.enterprise.context.SessionScoped$",
+                    "^@jakarta.enterprise.context.RequestScoped$"
+            );
+        }
+    }
+
+    /**
+     * enumに追加のアノテーションを付与する
+     */
+    @Test
+    public void additionalEnumTypeAnnotations() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("additionalEnumTypeAnnotations", "@jakarta.enterprise.context.SessionScoped;@jakarta.enterprise.context.RequestScoped;");
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("projects_with_enum.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> generatedFiles = generator.opts(clientOptInput).generate();
+
+        String[] expectedGenerateFiles = {
+                "src/gen/java/org/openapitools/api/ProjectsApi.java",
+                "src/gen/java/org/openapitools/api/UsersApi.java",
+                "src/gen/java/org/openapitools/model/ProjectRequest.java",
+                "src/gen/java/org/openapitools/model/ProjectResponse.java",
+                "src/gen/java/org/openapitools/model/Client.java",
+                "src/gen/java/org/openapitools/model/UserRequest.java",
+                "src/gen/java/org/openapitools/model/UserResponse.java",
+                "src/gen/java/org/openapitools/model/ErrorResponse.java"
+        };
+
+        // 生成されたファイルが存在することを確認
+        GeneratorAssertions.assertExistsFiles(
+                output,
+                generatedFiles,
+                mergeSupportFilesDocumentSpecifiedFiles(expectedGenerateFiles)
+        );
+        // 生成されたJavaソースコードが正しい構文であることを確認
+        GeneratorAssertions.assertValidJavaSourceSyntax(generatedFiles);
+
+        // サポートファイルを除いた生成されたファイルのリストを作成
+        List<File> generatedFilesExcludeSupportFiles = excludeSupportFiles(generatedFiles);
+
+        // 生成されたファイルと期待値を比較して、内容が一致することを確認
+        for (File generateFile : generatedFilesExcludeSupportFiles) {
+            GeneratorAssertions.assertEqualsFileContents(
+                    generateFile,
+                    getExpectedResourceFile(output, generateFile),
+                    IGNORE_GENERATED_ANNOTATION_PATTERN
+            );
+        }
+
+        // enumを持つモデルに追加のアノテーションが付与されていることを確認
+        List<File> generatedModelFiles = filterFiles(generatedFiles, "src/gen/java/org/openapitools/model/Client.java");
+
+        for (File generatedModelFile : generatedModelFiles) {
+            GeneratorAssertions.assertContainsPatterns(
+                    generatedModelFile,
+                    "^\\s*@jakarta.enterprise.context.SessionScoped$",
+                    "^\\s*@jakarta.enterprise.context.RequestScoped$"
+            );
+        }
+    }
+
+    /**
+     * プロパティをStringとして出力する
+     */
+    @Test
+    public void primitivePropertiesAsString() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("primitivePropertiesAsString", true);
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("projects_with_enum.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> generatedFiles = generator.opts(clientOptInput).generate();
+
+        String[] expectedGenerateFiles = {
+                // パッケージはデフォルト
+                "src/gen/java/org/openapitools/api/ProjectsApi.java",
+                "src/gen/java/org/openapitools/api/UsersApi.java",
+                "src/gen/java/org/openapitools/model/ProjectRequest.java",
+                "src/gen/java/org/openapitools/model/ProjectResponse.java",
+                "src/gen/java/org/openapitools/model/Client.java",
+                "src/gen/java/org/openapitools/model/UserRequest.java",
+                "src/gen/java/org/openapitools/model/UserResponse.java",
+                "src/gen/java/org/openapitools/model/ErrorResponse.java"
+        };
+
+        // 生成されたファイルが存在することを確認
+        GeneratorAssertions.assertExistsFiles(
+                output,
+                generatedFiles,
+                mergeSupportFilesDocumentSpecifiedFiles(expectedGenerateFiles)
+        );
+        // 生成されたJavaソースコードが正しい構文であることを確認
+        GeneratorAssertions.assertValidJavaSourceSyntax(generatedFiles);
+
+        // サポートファイルを除いた生成されたファイルのリストを作成
+        List<File> generatedFilesExcludeSupportFiles = excludeSupportFiles(generatedFiles);
+
+        // 生成されたファイルと期待値を比較して、内容が一致することを確認
+        for (File generateFile : generatedFilesExcludeSupportFiles) {
+            GeneratorAssertions.assertEqualsFileContents(
+                    generateFile,
+                    getExpectedResourceFile(output, generateFile),
+                    IGNORE_GENERATED_ANNOTATION_PATTERN
+            );
+        }
+
+        // IntegerやLongのようなプリミティブ型が出現しないことを確認
+        for (File generatedFile : generatedFilesExcludeSupportFiles) {
+            GeneratorAssertions.assertNotContainsPatterns(
+                    generatedFile,
+                    "Integer",
+                    "Long",
+                    "Float",
+                    "Double",
+                    "BigDecimal",
+                    "Boolean",
+                    "byte\\[\\]",
+                    "File",
+                    "LocalDate",
+                    "OffsetDateTime",
+                    "UUID",
+                    "URI"
+            );
+        }
+    }
+
+    /**
+     * サポートしていないリクエストのメディアタイプを指定した場合
+     */
+    @Test
+    public void unsupportedConsumesMediaTypes() {
+        Map<String, Object> properties = new HashMap<>();
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("projects_consumes_media_types.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+
+        try {
+            // デフォルトではapplication/jsonのみ受け付ける
+            generator.opts(clientOptInput).generate();
+
+            fail();
+        } catch (RuntimeException e) {
+            assertTrue(e.getMessage().contains("Could not process operation"));
+
+            assertTrue(e.getCause() instanceof UnsupportedOperationException);
+            assertEquals("Unsupported consumes media types: [application/xml]", e.getCause().getMessage());
+        }
+    }
+
+    /**
+     * サポートするリクエストのメディアタイプを設定する
+     */
+    @Test
+    public void supportConsumesMediaTypes() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("supportConsumesMediaTypes", "application/json,application/xml");
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("projects_consumes_media_types.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> generatedFiles = generator.opts(clientOptInput).generate();
+
+        String[] expectedGenerateFiles = {
+                "src/gen/java/org/openapitools/api/ProjectsApi.java",
+                "src/gen/java/org/openapitools/api/UsersApi.java",
+                "src/gen/java/org/openapitools/model/ProjectRequest.java",
+                "src/gen/java/org/openapitools/model/ProjectResponse.java",
+                "src/gen/java/org/openapitools/model/Client.java",
+                "src/gen/java/org/openapitools/model/UserRequest.java",
+                "src/gen/java/org/openapitools/model/UserResponse.java",
+                "src/gen/java/org/openapitools/model/ErrorResponse.java"
+        };
+
+        // 生成されたファイルが存在することを確認
+        GeneratorAssertions.assertExistsFiles(
+                output,
+                generatedFiles,
+                mergeSupportFilesDocumentSpecifiedFiles(expectedGenerateFiles)
+        );
+        // 生成されたJavaソースコードが正しい構文であることを確認
+        GeneratorAssertions.assertValidJavaSourceSyntax(generatedFiles);
+
+        // サポートファイルを除いた生成されたファイルのリストを作成
+        List<File> generatedFilesExcludeSupportFiles = excludeSupportFiles(generatedFiles);
+
+        // 生成されたファイルと期待値を比較して、内容が一致することを確認
+        for (File generateFile : generatedFilesExcludeSupportFiles) {
+            GeneratorAssertions.assertEqualsFileContents(
+                    generateFile,
+                    getExpectedResourceFile(output, generateFile),
+                    IGNORE_GENERATED_ANNOTATION_PATTERN
+            );
+        }
+
+        // リクエストのメディアタイプがapplication/jsonとapplication/xmlに対応していることを確認
+        List<File> generatedApiFiles = filterApiFiles(generatedFiles, "src/gen/java/org/openapitools/api");
+
+        for (File generatedApiFile : generatedApiFiles) {
+            GeneratorAssertions.assertContainsPatterns(
+                    generatedApiFile,
+                    "@Consumes\\(\\{ \"application/json\", \"application/xml\" \\}\\)"
+            );
+        }
+    }
+
+    /**
+     * サポートしていないレスポンスのメディアタイプを指定した場合
+     */
+    @Test
+    public void unsupportedProducesMediaTypes() {
+        Map<String, Object> properties = new HashMap<>();
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("projects_produces_media_types.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+
+        try {
+            // デフォルトではapplication/jsonのみ受け付ける
+            generator.opts(clientOptInput).generate();
+
+            fail();
+        } catch (RuntimeException e) {
+            assertTrue(e.getMessage().contains("Could not process operation"));
+
+            assertTrue(e.getCause() instanceof UnsupportedOperationException);
+            assertEquals("Unsupported produces media types: [application/xml]", e.getCause().getMessage());
+        }
+    }
+
+    /**
+     * サポートするレスポンスのメディアタイプを設定する
+     */
+    @Test
+    public void supportProducesMediaTypes() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("supportProducesMediaTypes", "application/json,application/xml");
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("projects_produces_media_types.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> generatedFiles = generator.opts(clientOptInput).generate();
+
+        String[] expectedGenerateFiles = {
+                "src/gen/java/org/openapitools/api/ProjectsApi.java",
+                "src/gen/java/org/openapitools/api/UsersApi.java",
+                "src/gen/java/org/openapitools/model/ProjectRequest.java",
+                "src/gen/java/org/openapitools/model/ProjectResponse.java",
+                "src/gen/java/org/openapitools/model/Client.java",
+                "src/gen/java/org/openapitools/model/UserRequest.java",
+                "src/gen/java/org/openapitools/model/UserResponse.java",
+                "src/gen/java/org/openapitools/model/ErrorResponse.java"
+        };
+
+        // 生成されたファイルが存在することを確認
+        GeneratorAssertions.assertExistsFiles(
+                output,
+                generatedFiles,
+                mergeSupportFilesDocumentSpecifiedFiles(expectedGenerateFiles)
+        );
+        // 生成されたJavaソースコードが正しい構文であることを確認
+        GeneratorAssertions.assertValidJavaSourceSyntax(generatedFiles);
+
+        // サポートファイルを除いた生成されたファイルのリストを作成
+        List<File> generatedFilesExcludeSupportFiles = excludeSupportFiles(generatedFiles);
+
+        // 生成されたファイルと期待値を比較して、内容が一致することを確認
+        for (File generateFile : generatedFilesExcludeSupportFiles) {
+            GeneratorAssertions.assertEqualsFileContents(
+                    generateFile,
+                    getExpectedResourceFile(output, generateFile),
+                    IGNORE_GENERATED_ANNOTATION_PATTERN
+            );
+        }
+
+        // レスポンスのメディアタイプがapplication/jsonとapplication/xmlに対応していることを確認
+        List<File> generatedApiFiles = filterApiFiles(generatedFiles, "src/gen/java/org/openapitools/api");
+
+        for (File generatedApiFile : generatedApiFiles) {
+            GeneratorAssertions.assertContainsPatterns(
+                    generatedApiFile,
+                    "@Produces\\(\\{ \"application/json\", \"application/xml\" \\}\\)"
+            );
+        }
+    }
+}

--- a/src/test/java/nablarch/tool/openapi/codegen/DataTypeVariationTest.java
+++ b/src/test/java/nablarch/tool/openapi/codegen/DataTypeVariationTest.java
@@ -1,0 +1,380 @@
+package nablarch.tool.openapi.codegen;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import nablarch.tool.openapi.codegen.test.GeneratorAssertions;
+import nablarch.tool.openapi.codegen.test.JavaNablarchJaxrsServerCodegenOpenApi30TestSupport;
+import org.junit.Test;
+import org.openapitools.codegen.ClientOptInput;
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.config.CodegenConfigurator;
+
+/**
+ * OpenAPIで利用可能なデータ型、フォーマットに対する{@link JavaNablarchJaxrsServerCodegen}の振る舞いを確認するテストクラス。
+ */
+public class DataTypeVariationTest extends JavaNablarchJaxrsServerCodegenOpenApi30TestSupport {
+    /**
+     * 明示的にサポートする全データ型、フォーマットの組み合わせの出力結果を確認する
+     */
+    @Test
+    public void allDataTypes() {
+        Map<String, Object> properties = new HashMap<>();
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("all_data_types.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> generatedFiles = generator.opts(clientOptInput).generate();
+
+        String[] expectedGenerateFiles = {
+                "src/gen/java/org/openapitools/api/DataTypesApi.java",
+                "src/gen/java/org/openapitools/model/DataTypeRequest.java",
+                "src/gen/java/org/openapitools/model/DataSubTypeRequest.java",
+                "src/gen/java/org/openapitools/model/DataTypeResponse.java",
+                "src/gen/java/org/openapitools/model/DataSubTypeResponse.java"
+        };
+
+        // 生成されたファイルが存在することを確認
+        GeneratorAssertions.assertExistsFiles(
+                output,
+                generatedFiles,
+                mergeSupportFilesDocumentSpecifiedFiles(expectedGenerateFiles)
+        );
+        // 生成されたJavaソースコードが正しい構文であることを確認
+        GeneratorAssertions.assertValidJavaSourceSyntax(generatedFiles);
+
+        // サポートファイルを除いた生成されたファイルのリストを作成
+        List<File> generatedFilesExcludeSupportFiles = excludeSupportFiles(generatedFiles);
+
+        // 生成されたファイルと期待値を比較して、内容が一致することを確認
+        for (File generateFile : generatedFilesExcludeSupportFiles) {
+            GeneratorAssertions.assertEqualsFileContents(
+                    generateFile,
+                    getExpectedResourceFile(output, generateFile),
+                    IGNORE_GENERATED_ANNOTATION_PATTERN
+            );
+        }
+    }
+
+    /**
+     * 明示的にサポートすることも謳わないデータ型、フォーマットも含めて、全データ型、フォーマットの組み合わせの出力結果を確認する。
+     * <p>
+     * ただしデータ型が{@code string}、フォーマットが{@code binary}の場合は明確に未サポートなので除く。
+     */
+    @Test
+    public void allDataTypesIncludedUnofficialSupportedTypes() {
+        Map<String, Object> properties = new HashMap<>();
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("all_data_types_included_unofficial_supported_types.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> generatedFiles = generator.opts(clientOptInput).generate();
+
+        String[] expectedGenerateFiles = {
+                "src/gen/java/org/openapitools/api/DataTypesApi.java",
+                "src/gen/java/org/openapitools/model/DataTypeRequest.java",
+                "src/gen/java/org/openapitools/model/DataSubTypeRequest.java",
+                "src/gen/java/org/openapitools/model/DataTypeResponse.java",
+                "src/gen/java/org/openapitools/model/DataSubTypeResponse.java"
+        };
+
+        // 生成されたファイルが存在することを確認
+        GeneratorAssertions.assertExistsFiles(
+                output,
+                generatedFiles,
+                mergeSupportFilesDocumentSpecifiedFiles(expectedGenerateFiles)
+        );
+        // 生成されたJavaソースコードが正しい構文であることを確認
+        GeneratorAssertions.assertValidJavaSourceSyntax(generatedFiles);
+
+        // サポートファイルを除いた生成されたファイルのリストを作成
+        List<File> generatedFilesExcludeSupportFiles = excludeSupportFiles(generatedFiles);
+
+        // 生成されたファイルと期待値を比較して、内容が一致することを確認
+        for (File generateFile : generatedFilesExcludeSupportFiles) {
+            GeneratorAssertions.assertEqualsFileContents(
+                    generateFile,
+                    getExpectedResourceFile(output, generateFile),
+                    IGNORE_GENERATED_ANNOTATION_PATTERN
+            );
+        }
+    }
+
+    /**
+     * プリミティブ型のプロパティを文字列型として扱う設定でサポートする全データ型、フォーマットの組み合わせの出力結果を確認する。
+     */
+    @Test
+    public void allDataTypesPrimitivePropertiesAsString() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("primitivePropertiesAsString", true);
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("all_data_types.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> generatedFiles = generator.opts(clientOptInput).generate();
+
+        String[] expectedGenerateFiles = {
+                "src/gen/java/org/openapitools/api/DataTypesApi.java",
+                "src/gen/java/org/openapitools/model/DataTypeRequest.java",
+                "src/gen/java/org/openapitools/model/DataSubTypeRequest.java",
+                "src/gen/java/org/openapitools/model/DataTypeResponse.java",
+                "src/gen/java/org/openapitools/model/DataSubTypeResponse.java"
+        };
+
+        // 生成されたファイルが存在することを確認
+        GeneratorAssertions.assertExistsFiles(
+                output,
+                generatedFiles,
+                mergeSupportFilesDocumentSpecifiedFiles(expectedGenerateFiles)
+        );
+        // 生成されたJavaソースコードが正しい構文であることを確認
+        GeneratorAssertions.assertValidJavaSourceSyntax(generatedFiles);
+
+        // サポートファイルを除いた生成されたファイルのリストを作成
+        List<File> generatedFilesExcludeSupportFiles = excludeSupportFiles(generatedFiles);
+
+        // 生成されたファイルと期待値を比較して、内容が一致することを確認
+        for (File generateFile : generatedFilesExcludeSupportFiles) {
+            GeneratorAssertions.assertEqualsFileContents(
+                    generateFile,
+                    getExpectedResourceFile(output, generateFile),
+                    IGNORE_GENERATED_ANNOTATION_PATTERN
+            );
+        }
+    }
+
+    /**
+     * メディアタイプがmultipart/form-dataではなく、リクエスト内にデータ型が{@code string}、フォーマットが{@code binary}のフィールドを含む場合、
+     * 生成に失敗することを確認する
+     */
+    @Test
+    public void unsupportedBinaryFormatRequest() {
+        Map<String, Object> properties = new HashMap<>();
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("all_data_types_with_binary_request.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+
+        try {
+            generator.opts(clientOptInput).generate();
+
+            fail();
+        } catch (RuntimeException e) {
+            assertTrue(e.getMessage().contains("Please make sure that your schema is correct!"));
+
+            assertTrue(e.getCause() instanceof UnsupportedOperationException);
+            assertEquals("property type: string and format: binary are not supported", e.getCause().getMessage());
+        }
+    }
+
+    /**
+     * レスポンス内にデータ型が{@code string}、フォーマットが{@code binary}のフィールドを含む場合、生成に失敗することを確認する。
+     */
+    @Test
+    public void unsupportedBinaryFormatResponse() {
+        Map<String, Object> properties = new HashMap<>();
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("all_data_types_with_binary_response.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+
+        try {
+            generator.opts(clientOptInput).generate();
+
+            fail();
+        } catch (RuntimeException e) {
+            assertTrue(e.getMessage().contains("Please make sure that your schema is correct!"));
+
+            assertTrue(e.getCause() instanceof UnsupportedOperationException);
+            assertEquals("property type: string and format: binary are not supported", e.getCause().getMessage());
+        }
+    }
+
+    /**
+     * リクエストでフォーマットが{@code binary}のフィールドを指定してもエラーにならないことを確認する。
+     * <p>
+     * なお、モデルは生成されない。
+     */
+    @Test
+    public void includeMultipartBinaryFormatRequest() {
+        Map<String, Object> properties = new HashMap<>();
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("all_data_types_with_multipart_binary_request.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> generatedFiles = generator.opts(clientOptInput).generate();
+
+        String[] expectedGenerateFiles = {
+                "src/gen/java/org/openapitools/api/DataTypesApi.java",
+                // multipart/form-dataのみで設定されたモデルは生成されなくなる
+                // "src/gen/java/org/openapitools/model/DataTypeRequest.java",
+                "src/gen/java/org/openapitools/model/DataSubTypeRequest.java",
+                "src/gen/java/org/openapitools/model/DataTypeResponse.java",
+                "src/gen/java/org/openapitools/model/DataSubTypeResponse.java"
+        };
+
+        // 生成されたファイルが存在することを確認
+        GeneratorAssertions.assertExistsFiles(
+                output,
+                generatedFiles,
+                mergeSupportFilesDocumentSpecifiedFiles(expectedGenerateFiles)
+        );
+        // 生成されたJavaソースコードが正しい構文であることを確認
+        GeneratorAssertions.assertValidJavaSourceSyntax(generatedFiles);
+
+        // サポートファイルを除いた生成されたファイルのリストを作成
+        List<File> generatedFilesExcludeSupportFiles = excludeSupportFiles(generatedFiles);
+
+        // 生成されたファイルと期待値を比較して、内容が一致することを確認
+        for (File generateFile : generatedFilesExcludeSupportFiles) {
+            GeneratorAssertions.assertEqualsFileContents(
+                    generateFile,
+                    getExpectedResourceFile(output, generateFile),
+                    IGNORE_GENERATED_ANNOTATION_PATTERN
+            );
+        }
+    }
+
+    /**
+     * メディアタイプに明示的に{@code multipart/form-data}を指定した場合、データ型が{@code string}、フォーマットに
+     * {@code binary}のフィールドを指定してもエラーになることを確認する。
+     * <p>
+     * リクエストと異なり、レスポンスでのマルチパートはサポートしない。
+     */
+    @Test
+    public void unsupportedMultipartWithBinaryFormatResponse() {
+        Map<String, Object> properties = new HashMap<>();
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("all_data_types_with_multipart_binary_response.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+
+        try {
+            generator.opts(clientOptInput).generate();
+
+            fail();
+        } catch (RuntimeException e) {
+            System.out.println((e.getMessage()));
+            assertTrue(e.getMessage().contains("Could not process operation"));
+
+            assertTrue(e.getCause() instanceof UnsupportedOperationException);
+            assertEquals("property type: string and format: binary are not supported", e.getCause().getMessage());
+        }
+    }
+
+    /**
+     * ファイルダウンロード向けのレスポンス定義を処理できることを確認する。
+     */
+    @Test
+    public void supportFileDownload() {
+        Map<String, Object> properties = new HashMap<>();
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("file_download.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> generatedFiles = generator.opts(clientOptInput).generate();
+
+        String[] expectedGenerateFiles = {
+                "src/gen/java/org/openapitools/api/DataTypesApi.java"
+        };
+
+        // 生成されたファイルが存在することを確認
+        GeneratorAssertions.assertExistsFiles(
+                output,
+                generatedFiles,
+                mergeSupportFilesDocumentSpecifiedFiles(expectedGenerateFiles)
+        );
+        // 生成されたJavaソースコードが正しい構文であることを確認
+        GeneratorAssertions.assertValidJavaSourceSyntax(generatedFiles);
+
+        // サポートファイルを除いた生成されたファイルのリストを作成
+        List<File> generatedFilesExcludeSupportFiles = excludeSupportFiles(generatedFiles);
+
+        // 生成されたファイルと期待値を比較して、内容が一致することを確認
+        for (File generateFile : generatedFilesExcludeSupportFiles) {
+            GeneratorAssertions.assertEqualsFileContents(
+                    generateFile,
+                    getExpectedResourceFile(output, generateFile),
+                    IGNORE_GENERATED_ANNOTATION_PATTERN
+            );
+        }
+
+        List<File> generatedApiFiles = filterApiFiles(generatedFiles, "src/gen/java/org/openapitools/api");
+
+        for (File generatedApiFile : generatedApiFiles) {
+            GeneratorAssertions.assertContainsPatterns(
+                    generatedApiFile,
+                    // メソッドの戻り値がHttpResponseになっている
+                    "^    HttpResponse"
+            );
+
+            GeneratorAssertions.assertNotContainsPatterns(
+                    generatedApiFile,
+                    // @Producesアノテーションは出力されない
+                    "^    @Produces"
+            );
+        }
+    }
+}

--- a/src/test/java/nablarch/tool/openapi/codegen/HttpMethodVariationTest.java
+++ b/src/test/java/nablarch/tool/openapi/codegen/HttpMethodVariationTest.java
@@ -1,0 +1,63 @@
+package nablarch.tool.openapi.codegen;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import nablarch.tool.openapi.codegen.test.GeneratorAssertions;
+import nablarch.tool.openapi.codegen.test.JavaNablarchJaxrsServerCodegenOpenApi30TestSupport;
+import org.junit.Test;
+import org.openapitools.codegen.ClientOptInput;
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.config.CodegenConfigurator;
+
+/**
+ * {@link JavaNablarchJaxrsServerCodegen}でサポートするHTTPメソッドのバリエーションをテストするクラス。
+ */
+public class HttpMethodVariationTest extends JavaNablarchJaxrsServerCodegenOpenApi30TestSupport {
+    /**
+     * サポートしているHTTPメソッド（GET、POST、PUT、DELETE、PATCH、OPTIONS）のバリエーションをテストする。
+     */
+    @Test
+    public void httpMethodsVariation() {
+        Map<String, Object> properties = new HashMap<>();
+        
+                File output = createGeneratorOutputDirectory();
+        
+                CodegenConfigurator configurator = new CodegenConfigurator()
+                        .setGeneratorName(GENERATOR_NAME)
+                        .setAdditionalProperties(properties)
+                        .setInputSpec(getTestClassResourcePath("supported_http_methods.yaml"))
+                        .setOutputDir(output.getAbsolutePath());
+        
+                ClientOptInput clientOptInput = configurator.toClientOptInput();
+                DefaultGenerator generator = new DefaultGenerator();
+                List<File> generatedFiles = generator.opts(clientOptInput).generate();
+        
+                String[] expectedGenerateFiles = {
+                        "src/gen/java/org/openapitools/api/HttpMethodsApi.java"
+                };
+        
+                // 生成されたファイルが存在することを確認
+                GeneratorAssertions.assertExistsFiles(
+                        output,
+                        generatedFiles,
+                        mergeSupportFilesDocumentSpecifiedFiles(expectedGenerateFiles)
+                );
+                // 生成されたJavaソースコードが正しい構文であることを確認
+                GeneratorAssertions.assertValidJavaSourceSyntax(generatedFiles);
+        
+                // サポートファイルを除いた生成されたファイルのリストを作成
+                List<File> generatedFilesExcludeSupportFiles = excludeSupportFiles(generatedFiles);
+        
+                // 生成されたファイルと期待値を比較して、内容が一致することを確認
+                for (File generateFile : generatedFilesExcludeSupportFiles) {
+                    GeneratorAssertions.assertEqualsFileContents(
+                            generateFile,
+                            getExpectedResourceFile(output, generateFile),
+                            IGNORE_GENERATED_ANNOTATION_PATTERN
+                    );
+                }
+    }
+}

--- a/src/test/java/nablarch/tool/openapi/codegen/OpenApiGeneratorSpecBenchmarkTest.java
+++ b/src/test/java/nablarch/tool/openapi/codegen/OpenApiGeneratorSpecBenchmarkTest.java
@@ -1,0 +1,113 @@
+package nablarch.tool.openapi.codegen;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import nablarch.tool.openapi.codegen.test.GeneratorAssertions;
+import nablarch.tool.openapi.codegen.test.JavaNablarchJaxrsServerCodegenOpenApi30TestSupport;
+import org.junit.Test;
+import org.openapitools.codegen.ClientOptInput;
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.config.CodegenConfigurator;
+
+/**
+ * OpenAPI Generatorのテストから汎用的なリソースを流用し、基本的な動作確認を行うためのテストクラス
+ */
+public class OpenApiGeneratorSpecBenchmarkTest extends JavaNablarchJaxrsServerCodegenOpenApi30TestSupport {
+    @Test
+    public void generatePing() throws Exception {
+        Map<String, Object> properties = new HashMap<>();
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("ping.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> generatedFiles = generator.opts(clientOptInput).generate();
+
+        String[] expectedGenerateFiles = {
+                "src/gen/java/org/openapitools/api/PingApi.java"
+        };
+
+        // 生成されたファイルが存在することを確認
+        GeneratorAssertions.assertExistsFiles(
+                output,
+                generatedFiles,
+                mergeSupportFilesDocumentSpecifiedFiles(expectedGenerateFiles)
+        );
+        // 生成されたJavaソースコードが正しい構文であることを確認
+        GeneratorAssertions.assertValidJavaSourceSyntax(generatedFiles);
+
+        // サポートファイルを除いた生成されたファイルのリストを作成
+        List<File> generatedFilesExcludeSupportFiles = excludeSupportFiles(generatedFiles);
+
+        // 生成されたファイルと期待値を比較して、内容が一致することを確認
+        for (File generateFile : generatedFilesExcludeSupportFiles) {
+            GeneratorAssertions.assertEqualsFileContents(
+                    generateFile,
+                    getExpectedResourceFile(output, generateFile),
+                    IGNORE_GENERATED_ANNOTATION_PATTERN
+            );
+        }
+    }
+
+    @Test
+    public void generatePetStore() throws Exception {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(JavaNablarchJaxrsServerCodegen.SUPPORT_CONSUMES_MEDIA_TYPES, "application/json, application/xml, application/x-www-form-urlencoded, multipart/form-data");
+        properties.put(JavaNablarchJaxrsServerCodegen.SUPPORT_PRODUCES_MEDIA_TYPES, "application/json, application/xml");
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("petstore.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> generatedFiles = generator.opts(clientOptInput).generate();
+
+        String[] expectedGenerateFiles = {
+                "src/gen/java/org/openapitools/api/PetApi.java",
+                "src/gen/java/org/openapitools/api/StoreApi.java",
+                "src/gen/java/org/openapitools/api/UserApi.java",
+                "src/gen/java/org/openapitools/model/Pet.java",
+                "src/gen/java/org/openapitools/model/Tag.java",
+                "src/gen/java/org/openapitools/model/Order.java",
+                "src/gen/java/org/openapitools/model/User.java",
+                "src/gen/java/org/openapitools/model/Category.java",
+                // ApiResponseはAbstractJavaCodegenでの予約語のため、先頭に"Model"（生成する種類名）が付与される
+                "src/gen/java/org/openapitools/model/ModelApiResponse.java"
+        };
+
+        // 生成されたファイルが存在することを確認
+        GeneratorAssertions.assertExistsFiles(
+                output,
+                generatedFiles,
+                mergeSupportFilesDocumentSpecifiedFiles(expectedGenerateFiles)
+        );
+        // 生成されたJavaソースコードが正しい構文であることを確認
+        GeneratorAssertions.assertValidJavaSourceSyntax(generatedFiles);
+
+        // サポートファイルを除いた生成されたファイルのリストを作成
+        List<File> generatedFilesExcludeSupportFiles = excludeSupportFiles(generatedFiles);
+
+        // 生成されたファイルと期待値を比較して、内容が一致することを確認
+        for (File generateFile : generatedFilesExcludeSupportFiles) {
+            GeneratorAssertions.assertEqualsFileContents(
+                    generateFile,
+                    getExpectedResourceFile(output, generateFile),
+                    IGNORE_GENERATED_ANNOTATION_PATTERN
+            );
+        }
+    }
+}

--- a/src/test/java/nablarch/tool/openapi/codegen/ValidationVariationTest.java
+++ b/src/test/java/nablarch/tool/openapi/codegen/ValidationVariationTest.java
@@ -1,0 +1,61 @@
+package nablarch.tool.openapi.codegen;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import nablarch.tool.openapi.codegen.test.GeneratorAssertions;
+import nablarch.tool.openapi.codegen.test.JavaNablarchJaxrsServerCodegenOpenApi30TestSupport;
+import org.junit.Test;
+import org.openapitools.codegen.ClientOptInput;
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.config.CodegenConfigurator;
+
+public class ValidationVariationTest extends JavaNablarchJaxrsServerCodegenOpenApi30TestSupport {
+    @Test
+    public void allSupportedValidations() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("useBeanValidation", true);
+
+        File output = createGeneratorOutputDirectory();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(GENERATOR_NAME)
+                .setAdditionalProperties(properties)
+                .setInputSpec(getTestClassResourcePath("validations.yaml"))
+                .setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> generatedFiles = generator.opts(clientOptInput).generate();
+
+        String[] expectedGenerateFiles = {
+                "src/gen/java/org/openapitools/api/ValidationsApi.java",
+                "src/gen/java/org/openapitools/model/ValidationRequest.java",
+                "src/gen/java/org/openapitools/model/ValidationSubRequest.java",
+                "src/gen/java/org/openapitools/model/ValidationResponse.java"
+        };
+
+        // 生成されたファイルが存在することを確認
+        GeneratorAssertions.assertExistsFiles(
+                output,
+                generatedFiles,
+                mergeSupportFilesDocumentSpecifiedFiles(expectedGenerateFiles)
+        );
+        // 生成されたJavaソースコードが正しい構文であることを確認
+        GeneratorAssertions.assertValidJavaSourceSyntax(generatedFiles);
+
+        // サポートファイルを除いた生成されたファイルのリストを作成
+        List<File> generatedFilesExcludeSupportFiles = excludeSupportFiles(generatedFiles);
+
+        // 生成されたファイルと期待値を比較して、内容が一致することを確認
+        for (File generateFile : generatedFilesExcludeSupportFiles) {
+            GeneratorAssertions.assertEqualsFileContents(
+                    generateFile,
+                    getExpectedResourceFile(output, generateFile),
+                    IGNORE_GENERATED_ANNOTATION_PATTERN
+            );
+        }
+    }
+}

--- a/src/test/java/nablarch/tool/openapi/codegen/test/GeneratorAssertions.java
+++ b/src/test/java/nablarch/tool/openapi/codegen/test/GeneratorAssertions.java
@@ -1,0 +1,175 @@
+package nablarch.tool.openapi.codegen.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.CompilationUnit;
+
+/**
+ * Generatorのテストで使うアサーションのヘルパークラス。
+ */
+public class GeneratorAssertions {
+    /**
+     * Generatorにより生成されたファイルのうち、Javaソースコードの構文が正しいことを確認する。
+     *
+     * @param files Generatorにより生成されたファイル
+     */
+    public static void assertValidJavaSourceSyntax(List<File> files) {
+        files.forEach(f -> {
+                    if (f.getName().endsWith(".java")) {
+                        String fileContents = "";
+                        try {
+                            fileContents = Files.readString(f.toPath());
+                        } catch (IOException ignored) {
+
+                        }
+                        assertValidJavaSourceCode(fileContents);
+                    }
+                }
+        );
+    }
+
+    /**
+     * 指定されたJavaソースコード（文字列）が正しい構文であることを確認する。
+     *
+     * @param javaSourceCode Javaソースコード（文字列）
+     */
+    private static void assertValidJavaSourceCode(String javaSourceCode) {
+        ParserConfiguration config = new ParserConfiguration();
+        config.setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17);
+        JavaParser parser = new JavaParser(config);
+        ParseResult<CompilationUnit> parseResult = parser.parse(javaSourceCode);
+        assertTrue(String.valueOf(parseResult.getProblems()), parseResult.isSuccessful());
+    }
+
+    /**
+     * 生成されたファイルと、期待するファイルパスのリストを比較して、生成されたファイルと期待値が一致することを確認する。
+     * <p>
+     * Generatorにより生成されるファイルの過不足を確認する。
+     *
+     * @param output         ファイルの出力先ディレクトリ
+     * @param generatedFiles 生成されたファイル
+     * @param expectedFiles  期待するファイルパスのリスト
+     */
+    public static void assertExistsFiles(File output, List<File> generatedFiles, String... expectedFiles) {
+        List<String> generatedFilePaths =
+                generatedFiles
+                        .stream()
+                        .map(f -> output.toPath().toAbsolutePath().relativize(f.toPath()).toString())
+                        .sorted()
+                        .toList();
+
+        List<String> expectedFilePaths = Arrays.stream(expectedFiles).map(Path::of).map(Path::toString).sorted().toList();
+
+        assertEquals(expectedFilePaths, generatedFilePaths);
+    }
+
+    /**
+     * Generatorにより生成されたファイルと期待値のファイルの内容を比較して、内容が一致することを確認する。
+     * <p>
+     * タイムスタンプのように生成する度に異なる内容もあるので、比較の際に無視するパターンを指定可能とする。
+     *
+     * @param generatedFile  Generatorにより生成されたファイル
+     * @param expectedFile   期待値のファイル
+     * @param ignorePatterns 期待値と生成されたファイルの内容を比較する際に無視するパターン
+     */
+    public static void assertEqualsFileContents(File generatedFile, File expectedFile, String... ignorePatterns) {
+        try {
+            List<String> generatedContents = Files.readAllLines(generatedFile.toPath(), StandardCharsets.UTF_8);
+            List<String> expectedContents = Files.readAllLines(expectedFile.toPath(), StandardCharsets.UTF_8);
+
+            for (int i = 0; i < expectedContents.size(); i++) {
+                String expectedLine = expectedContents.get(i);
+                String generatedLine = generatedContents.get(i);
+
+                boolean ignoreLine = false;
+
+                for (String ignorePattern : ignorePatterns) {
+                    Pattern pattern = Pattern.compile(ignorePattern);
+
+                    if (pattern.matcher(expectedLine).find() && pattern.matcher(generatedLine).find()) {
+                        ignoreLine = true;
+                        break;
+                    }
+                }
+
+                if (!ignoreLine) {
+                    assertEquals(expectedLine, generatedLine);
+                }
+            }
+
+            assertEquals(String.format("generated: %s, expected: %s", generatedFile, expectedFile), expectedContents.size(), generatedContents.size());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * 指定されたファイルに、指定された正規表現パターンが含まれていることを確認する。特定の文字列が生成されたファイルに含まれているか
+     * 確認したい時に使用する。
+     *
+     * @param actualFile 確認対象のファイル
+     * @param patterns   正規表現パターン
+     */
+    public static void assertContainsPatterns(File actualFile, String... patterns) {
+        try {
+            List<String> actualContents = Files.readAllLines(actualFile.toPath(), StandardCharsets.UTF_8);
+
+            List<Pattern> compiledPattens = new ArrayList<>(Arrays.stream(patterns).map(Pattern::compile).toList());
+
+            for (String line : actualContents) {
+                List<Pattern> foundPatterns = new ArrayList<>();
+
+                for (Pattern p : compiledPattens) {
+                    if (p.matcher(line).find()) {
+                        foundPatterns.add(p);
+                    }
+                }
+
+                compiledPattens.removeAll(foundPatterns);
+            }
+
+            assertTrue(String.format("%s does not contain %s", actualFile, compiledPattens), compiledPattens.isEmpty());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * 指定されたファイルに、指定された正規表現パターンが含まれていないことを確認する。特定の文字列が生成されたファイルに含まれていないことを
+     * 確認したい時に使用する。
+     *
+     * @param actualFile 確認対象のファイル
+     * @param patterns   正規表現パターン
+     */
+    public static void assertNotContainsPatterns(File actualFile, String... patterns) {
+        try {
+            List<String> actualContents = Files.readAllLines(actualFile.toPath(), StandardCharsets.UTF_8);
+
+            List<Pattern> compiledPattens = Arrays.stream(patterns).map(Pattern::compile).toList();
+
+            for (String line : actualContents) {
+                for (Pattern p : compiledPattens) {
+                    assertFalse(String.format("%s contains %s", actualFile, p), p.matcher(line).find());
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/src/test/java/nablarch/tool/openapi/codegen/test/JavaNablarchJaxrsServerCodegenOpenApi30TestSupport.java
+++ b/src/test/java/nablarch/tool/openapi/codegen/test/JavaNablarchJaxrsServerCodegenOpenApi30TestSupport.java
@@ -1,0 +1,16 @@
+package nablarch.tool.openapi.codegen.test;
+
+/**
+ * OpenAPI 3.0.x用のNablarch JAX-RS Generatorのテストの基底クラス
+ */
+public abstract class JavaNablarchJaxrsServerCodegenOpenApi30TestSupport extends JavaNablarchJaxrsServerCodegenTestSupport {
+    /**
+     * OpenAPI 3.0.x用ののバージョンを返却する。
+     *
+     * @return OpenAPI 3.0.x用のバージョン
+     */
+    @Override
+    public String getVersion() {
+        return "openapi-3_0";
+    }
+}

--- a/src/test/java/nablarch/tool/openapi/codegen/test/JavaNablarchJaxrsServerCodegenTestSupport.java
+++ b/src/test/java/nablarch/tool/openapi/codegen/test/JavaNablarchJaxrsServerCodegenTestSupport.java
@@ -1,0 +1,188 @@
+package nablarch.tool.openapi.codegen.test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen;
+import org.junit.Rule;
+import org.junit.rules.TestName;
+
+/**
+ * Nablarch JAX-RS用のGeneratorのテストの基底クラス
+ */
+public abstract class JavaNablarchJaxrsServerCodegenTestSupport {
+    protected static final String GENERATOR_NAME = JavaNablarchJaxrsServerCodegen.GENERATOR_NAME;
+
+    // @Generatedアノテーションを無視するための正規表現
+    protected static final String IGNORE_GENERATED_ANNOTATION_PATTERN = "^@jakarta\\.annotation\\.Generated\\(value = \"nablarch\\.tool\\.openapi\\.codegen\\.JavaNablarchJaxrsServerCodegen\",.+";
+
+    // Generatorにより自動で生成されるサポートファイル
+    protected static final List<String> ALWAYS_GENERATE_SUPPORT_FILES = List.of(
+            ".openapi-generator-ignore",
+            ".openapi-generator/FILES",
+            ".openapi-generator/VERSION"
+    );
+
+    @Rule
+    public TestName testName = new TestName();
+
+    /**
+     * テストクラスが対象とするOpenAPIのバージョンを返却する。テストクラスが使用するリソースを配置するディレクトリパスの一部になる。
+     *
+     * @return テストクラスが対象とするOpenAPIのバージョン
+     */
+    public abstract String getVersion();
+
+    /**
+     * Generatorの実行結果を出力するディレクトリを作成する。
+     *
+     * @return Generatorの出力先ディレクトリ
+     */
+    protected File createGeneratorOutputDirectory() {
+        try {
+            Path outputDirectoryPath = Path.of("target/oai-gen-test-sources");
+            Files.createDirectories(outputDirectoryPath);
+            return Files
+                    .createTempDirectory(
+                            outputDirectoryPath,
+                            getClass().getSimpleName() + "-" + testName.getMethodName() + "-"
+                    ).toFile();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * パスをプラットフォーム非依存の表現に変換する。
+     *
+     * @param path パス
+     * @return 変換後のパス
+     */
+    private String toPlatformIndependentPath(String path) {
+        return path.replace("\\", "/");
+    }
+
+    /**
+     * 指定されたファイルのリストから、サポートファイルを除いたリストを作成する。
+     *
+     * @param files ファイルのリスト
+     * @return サポートファイルを除いたファイルのリスト
+     */
+    protected List<File> excludeSupportFiles(List<File> files) {
+        return files.stream()
+                .filter(file -> {
+                    for (String supportFile : ALWAYS_GENERATE_SUPPORT_FILES) {
+                        if (toPlatformIndependentPath(file.getPath()).endsWith(supportFile)) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                })
+                .toList();
+    }
+
+    /**
+     * Generatorで生成したファイルの中から、Api用のファイルのみを抽出する
+     *
+     * @param generatedFiles Generatorで生成したファイルのリスト
+     * @param apiPath Api用のファイルのパス
+     * @return Api用のファイルのリスト
+     */
+    protected List<File> filterApiFiles(List<File> generatedFiles, String apiPath) {
+        return generatedFiles
+                .stream()
+                .filter(file -> toPlatformIndependentPath(file.getPath()).contains(apiPath))
+                .toList();
+    }
+
+    /**
+     * Generatorで生成したファイルの中から、モデル用のファイルのみを抽出する
+     *
+     * @param generatedFiles Generatorで生成したファイルのリスト
+     * @param modelPath モデル用のファイルのパス
+     * @return モデル用のファイルのリスト
+     */
+    protected List<File> filterModelFiles(List<File> generatedFiles, String modelPath) {
+        return generatedFiles
+                .stream()
+                .filter(file -> toPlatformIndependentPath(file.getPath()).contains(modelPath))
+                .toList();
+    }
+
+    /**
+     * Generatorで生成したファイルの中から、指定されたパスに含まれるファイルのみを抽出する
+     *
+     * @param generatedFiles Generatorで生成したファイルのリスト
+     * @param paths 抽出するファイルのパス
+     * @return 抽出されたファイルのリスト
+     */
+    protected List<File> filterFiles(List<File> generatedFiles, String... paths) {
+        return generatedFiles
+                .stream()
+                .filter(file -> {
+                    String platformIndependentGeneratedPath = toPlatformIndependentPath(file.getPath());
+
+                    for (String path : paths) {
+                        String platformIndependentPath = toPlatformIndependentPath(path);
+                        if (platformIndependentGeneratedPath.contains(platformIndependentPath)) {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                })
+                .toList();
+    }
+
+    /**
+     * テストクラスに対応するリソースパスを取得する。
+     *
+     * @param path リソースパス
+     * @return テストクラスに対応するリソースパス
+     */
+    protected String getTestClassResourcePath(String path) {
+        return String.format("src/test/resources/%s/%s/%s", getVersion(), getClass().getSimpleName(), path);
+    }
+
+    /**
+     * 相対パス{@code path}を指定して、テストメソッドに対応する期待値となるファイルを配置したパスに変換する。
+     *
+     * @param path パス
+     * @return 期待値となるファイルを配置したパス
+     */
+    protected String getExpectedResourcePath(String path) {
+        return String.format("src/test/resources/%s/%s/%s/expected/%s", getVersion(), getClass().getSimpleName(), testName.getMethodName(), path);
+    }
+
+    /**
+     * 出力先ディレクトリとGeneratorで生成したファイルから、対応する期待値となるファイルのパスに変換する
+     *
+     * @param output 出力先ディレクトリ
+     * @param generatedFile Generatorで生成したファイル
+     * @return 期待値となるファイルのパス
+     */
+    protected File getExpectedResourceFile(File output, File generatedFile) {
+        String path = output.toPath().toAbsolutePath().relativize(generatedFile.toPath()).toString();
+        return new File(String.format("src/test/resources/%s/%s/%s/expected/%s", getVersion(), getClass().getSimpleName(), testName.getMethodName(), path));
+    }
+
+    /**
+     * 指定されたファイルリストと、常に生成されるサポートファイルをマージする。
+     *
+     * @param files ファイルリスト
+     * @return マージされたファイルリスト
+     */
+    protected String[] mergeSupportFilesDocumentSpecifiedFiles(String... files) {
+        return Stream.concat(
+                ALWAYS_GENERATE_SUPPORT_FILES.stream(),
+                Arrays.stream(files)
+        ).toArray(String[]::new);
+    }
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalEnumTypeAnnotations/expected/src/gen/java/org/openapitools/api/ProjectsApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalEnumTypeAnnotations/expected/src/gen/java/org/openapitools/api/ProjectsApi.java
@@ -1,0 +1,108 @@
+package org.openapitools.api;
+
+import org.openapitools.model.Client;
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.ProjectRequest;
+import org.openapitools.model.ProjectResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/projects")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.040665019+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface ProjectsApi {
+    /**
+     * POST  : プロジェクトを作成する
+     *
+     * 情報を指定してプロジェクトを作成する
+     *
+     * @param projectRequest プロジェクト登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> createProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : プロジェクトを削除する
+     *
+     * IDを指定してプロジェクトを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project deleted
+     * @return not found project
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{projectId}/clients : プロジェクト内のクライアント一覧取得
+     *
+     * プロジェクト内のクライアント一覧を取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return プロジェクト内のクライアント一覧
+     */
+    @GET
+    @Path("/{projectId}/clients")
+    @Produces({ "application/json" })
+    EntityResponse<List<Client>> findAllClientsInProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのプロジェクトを取得する
+     *
+     * すべてのプロジェクトを取得する。タグとソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all projects
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<ProjectResponse>> findAllProjects(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : プロジェクトを取得する
+     *
+     * IDを指定してプロジェクトを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find project by id
+     * @return not found project
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> findProjectById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : プロジェクトを更新する
+     *
+     * IDを指定してプロジェクトを更新する
+     *
+     * @param projectRequest プロジェクト更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project updated
+     * @return request invalid
+     * @return not found project
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    HttpResponse updateProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalEnumTypeAnnotations/expected/src/gen/java/org/openapitools/api/UsersApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalEnumTypeAnnotations/expected/src/gen/java/org/openapitools/api/UsersApi.java
@@ -1,0 +1,92 @@
+package org.openapitools.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.UserRequest;
+import org.openapitools.model.UserResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/users")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.040665019+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface UsersApi {
+    /**
+     * POST  : ユーザを作成する
+     *
+     * 情報を指定してユーザを作成する
+     *
+     * @param userRequest ユーザ登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> createUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : ユーザを削除する
+     *
+     * IDを指定してユーザを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user deleted
+     * @return not found user
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteUser(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのユーザを取得する
+     *
+     * すべてのユーザを取得する。ソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all users
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<UserResponse>> findAllUsers(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : ユーザを取得する
+     *
+     * IDを指定してユーザを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find user by id
+     * @return not found user
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> findUserById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : ユーザを更新する
+     *
+     * IDを指定してユーザを更新する
+     *
+     * @param userRequest ユーザ更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user updated
+     * @return request invalid
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    HttpResponse updateUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalEnumTypeAnnotations/expected/src/gen/java/org/openapitools/model/Client.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalEnumTypeAnnotations/expected/src/gen/java/org/openapitools/model/Client.java
@@ -1,0 +1,158 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * クライアント情報
+ */
+@JsonTypeName("Client")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.040665019+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class Client   {
+  private UUID id;
+  private String name;
+  @jakarta.enterprise.context.SessionScoped
+@jakarta.enterprise.context.RequestScoped
+public enum StatusEnum {
+
+    ACTIVE(String.valueOf("active")), INACTIVE(String.valueOf("inactive"));
+
+
+    private String value;
+
+    StatusEnum (String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static StatusEnum fromValue(String value) {
+        for (StatusEnum b : StatusEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+  private StatusEnum status;
+
+    /**
+     * クライアントID
+     */
+    public Client id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * クライアント名
+     */
+    public Client name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Client Status
+     */
+    public Client status(StatusEnum status) {
+        this.status = status;
+        return this;
+    }
+
+    
+    @JsonProperty("status")
+    public StatusEnum getStatus() {
+        return status;
+    }
+
+    @JsonProperty("status")
+    public void setStatus(StatusEnum status) {
+        this.status = status;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Client client = (Client) o;
+        return Objects.equals(this.id, client.id) &&
+            Objects.equals(this.name, client.name) &&
+            Objects.equals(this.status, client.status);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, status);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Client {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalEnumTypeAnnotations/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalEnumTypeAnnotations/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
@@ -1,0 +1,79 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * エラーレスポンス
+ */
+@JsonTypeName("ErrorResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.040665019+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ErrorResponse   {
+  private String message;
+
+    /**
+     * メッセージ
+     */
+    public ErrorResponse message(String message) {
+        this.message = message;
+        return this;
+    }
+
+    
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ErrorResponse errorResponse = (ErrorResponse) o;
+        return Objects.equals(this.message, errorResponse.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(message);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ErrorResponse {\n");
+        
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalEnumTypeAnnotations/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalEnumTypeAnnotations/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
@@ -1,0 +1,256 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト作成・更新情報
+ */
+@JsonTypeName("ProjectRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.040665019+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectRequest   {
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectRequest name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     * minimum: 1
+     */
+    public ProjectRequest sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     * minimum: 1
+     */
+    public ProjectRequest profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectRequest startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectRequest endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectRequest registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectRequest tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectRequest addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectRequest removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectRequest client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectRequest projectRequest = (ProjectRequest) o;
+        return Objects.equals(this.name, projectRequest.name) &&
+            Objects.equals(this.sales, projectRequest.sales) &&
+            Objects.equals(this.profit, projectRequest.profit) &&
+            Objects.equals(this.startDate, projectRequest.startDate) &&
+            Objects.equals(this.endDate, projectRequest.endDate) &&
+            Objects.equals(this.registeredDateTime, projectRequest.registeredDateTime) &&
+            Objects.equals(this.tags, projectRequest.tags) &&
+            Objects.equals(this.client, projectRequest.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectRequest {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalEnumTypeAnnotations/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalEnumTypeAnnotations/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
@@ -1,0 +1,277 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト情報
+ */
+@JsonTypeName("ProjectResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.040665019+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectResponse   {
+  private UUID id;
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクトID
+     */
+    public ProjectResponse id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectResponse name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     */
+    public ProjectResponse sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     */
+    public ProjectResponse profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectResponse startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectResponse endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectResponse registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectResponse tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectResponse addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectResponse removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectResponse client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectResponse projectResponse = (ProjectResponse) o;
+        return Objects.equals(this.id, projectResponse.id) &&
+            Objects.equals(this.name, projectResponse.name) &&
+            Objects.equals(this.sales, projectResponse.sales) &&
+            Objects.equals(this.profit, projectResponse.profit) &&
+            Objects.equals(this.startDate, projectResponse.startDate) &&
+            Objects.equals(this.endDate, projectResponse.endDate) &&
+            Objects.equals(this.registeredDateTime, projectResponse.registeredDateTime) &&
+            Objects.equals(this.tags, projectResponse.tags) &&
+            Objects.equals(this.client, projectResponse.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalEnumTypeAnnotations/expected/src/gen/java/org/openapitools/model/UserRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalEnumTypeAnnotations/expected/src/gen/java/org/openapitools/model/UserRequest.java
@@ -1,0 +1,147 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ登録・更新情報
+ */
+@JsonTypeName("UserRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.040665019+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserRequest   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserRequest firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserRequest lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     * minimum: 1
+     */
+    public UserRequest age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserRequest birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserRequest userRequest = (UserRequest) o;
+        return Objects.equals(this.firstName, userRequest.firstName) &&
+            Objects.equals(this.lastName, userRequest.lastName) &&
+            Objects.equals(this.age, userRequest.age) &&
+            Objects.equals(this.birthday, userRequest.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserRequest {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalEnumTypeAnnotations/expected/src/gen/java/org/openapitools/model/UserResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalEnumTypeAnnotations/expected/src/gen/java/org/openapitools/model/UserResponse.java
@@ -1,0 +1,146 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ情報
+ */
+@JsonTypeName("UserResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.040665019+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserResponse   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserResponse firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserResponse lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     */
+    public UserResponse age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserResponse birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserResponse userResponse = (UserResponse) o;
+        return Objects.equals(this.firstName, userResponse.firstName) &&
+            Objects.equals(this.lastName, userResponse.lastName) &&
+            Objects.equals(this.age, userResponse.age) &&
+            Objects.equals(this.birthday, userResponse.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserResponse {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalModelTypeAnnotations/expected/src/gen/java/org/openapitools/api/ProjectsApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalModelTypeAnnotations/expected/src/gen/java/org/openapitools/api/ProjectsApi.java
@@ -1,0 +1,108 @@
+package org.openapitools.api;
+
+import org.openapitools.model.Client;
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.ProjectRequest;
+import org.openapitools.model.ProjectResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/projects")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:04.420411643+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface ProjectsApi {
+    /**
+     * POST  : プロジェクトを作成する
+     *
+     * 情報を指定してプロジェクトを作成する
+     *
+     * @param projectRequest プロジェクト登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> createProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : プロジェクトを削除する
+     *
+     * IDを指定してプロジェクトを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project deleted
+     * @return not found project
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{projectId}/clients : プロジェクト内のクライアント一覧取得
+     *
+     * プロジェクト内のクライアント一覧を取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return プロジェクト内のクライアント一覧
+     */
+    @GET
+    @Path("/{projectId}/clients")
+    @Produces({ "application/json" })
+    EntityResponse<List<Client>> findAllClientsInProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのプロジェクトを取得する
+     *
+     * すべてのプロジェクトを取得する。タグとソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all projects
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<ProjectResponse>> findAllProjects(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : プロジェクトを取得する
+     *
+     * IDを指定してプロジェクトを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find project by id
+     * @return not found project
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> findProjectById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : プロジェクトを更新する
+     *
+     * IDを指定してプロジェクトを更新する
+     *
+     * @param projectRequest プロジェクト更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project updated
+     * @return request invalid
+     * @return not found project
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    HttpResponse updateProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalModelTypeAnnotations/expected/src/gen/java/org/openapitools/api/UsersApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalModelTypeAnnotations/expected/src/gen/java/org/openapitools/api/UsersApi.java
@@ -1,0 +1,92 @@
+package org.openapitools.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.UserRequest;
+import org.openapitools.model.UserResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/users")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:04.420411643+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface UsersApi {
+    /**
+     * POST  : ユーザを作成する
+     *
+     * 情報を指定してユーザを作成する
+     *
+     * @param userRequest ユーザ登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> createUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : ユーザを削除する
+     *
+     * IDを指定してユーザを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user deleted
+     * @return not found user
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteUser(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのユーザを取得する
+     *
+     * すべてのユーザを取得する。ソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all users
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<UserResponse>> findAllUsers(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : ユーザを取得する
+     *
+     * IDを指定してユーザを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find user by id
+     * @return not found user
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> findUserById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : ユーザを更新する
+     *
+     * IDを指定してユーザを更新する
+     *
+     * @param userRequest ユーザ更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user updated
+     * @return request invalid
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    HttpResponse updateUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalModelTypeAnnotations/expected/src/gen/java/org/openapitools/model/Client.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalModelTypeAnnotations/expected/src/gen/java/org/openapitools/model/Client.java
@@ -1,0 +1,104 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * クライアント情報
+ */
+@JsonTypeName("Client")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:04.420411643+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+@jakarta.enterprise.context.SessionScoped
+@jakarta.enterprise.context.RequestScoped
+public class Client   {
+  private UUID id;
+  private String name;
+
+    /**
+     * クライアントID
+     */
+    public Client id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * クライアント名
+     */
+    public Client name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Client client = (Client) o;
+        return Objects.equals(this.id, client.id) &&
+            Objects.equals(this.name, client.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Client {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalModelTypeAnnotations/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalModelTypeAnnotations/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
@@ -1,0 +1,81 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * エラーレスポンス
+ */
+@JsonTypeName("ErrorResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:04.420411643+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+@jakarta.enterprise.context.SessionScoped
+@jakarta.enterprise.context.RequestScoped
+public class ErrorResponse   {
+  private String message;
+
+    /**
+     * メッセージ
+     */
+    public ErrorResponse message(String message) {
+        this.message = message;
+        return this;
+    }
+
+    
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ErrorResponse errorResponse = (ErrorResponse) o;
+        return Objects.equals(this.message, errorResponse.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(message);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ErrorResponse {\n");
+        
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalModelTypeAnnotations/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalModelTypeAnnotations/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
@@ -1,0 +1,258 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト作成・更新情報
+ */
+@JsonTypeName("ProjectRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:04.420411643+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+@jakarta.enterprise.context.SessionScoped
+@jakarta.enterprise.context.RequestScoped
+public class ProjectRequest   {
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectRequest name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     * minimum: 1
+     */
+    public ProjectRequest sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     * minimum: 1
+     */
+    public ProjectRequest profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectRequest startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectRequest endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectRequest registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectRequest tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectRequest addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectRequest removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectRequest client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectRequest projectRequest = (ProjectRequest) o;
+        return Objects.equals(this.name, projectRequest.name) &&
+            Objects.equals(this.sales, projectRequest.sales) &&
+            Objects.equals(this.profit, projectRequest.profit) &&
+            Objects.equals(this.startDate, projectRequest.startDate) &&
+            Objects.equals(this.endDate, projectRequest.endDate) &&
+            Objects.equals(this.registeredDateTime, projectRequest.registeredDateTime) &&
+            Objects.equals(this.tags, projectRequest.tags) &&
+            Objects.equals(this.client, projectRequest.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectRequest {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalModelTypeAnnotations/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalModelTypeAnnotations/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
@@ -1,0 +1,279 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト情報
+ */
+@JsonTypeName("ProjectResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:04.420411643+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+@jakarta.enterprise.context.SessionScoped
+@jakarta.enterprise.context.RequestScoped
+public class ProjectResponse   {
+  private UUID id;
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクトID
+     */
+    public ProjectResponse id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectResponse name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     */
+    public ProjectResponse sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     */
+    public ProjectResponse profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectResponse startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectResponse endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectResponse registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectResponse tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectResponse addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectResponse removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectResponse client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectResponse projectResponse = (ProjectResponse) o;
+        return Objects.equals(this.id, projectResponse.id) &&
+            Objects.equals(this.name, projectResponse.name) &&
+            Objects.equals(this.sales, projectResponse.sales) &&
+            Objects.equals(this.profit, projectResponse.profit) &&
+            Objects.equals(this.startDate, projectResponse.startDate) &&
+            Objects.equals(this.endDate, projectResponse.endDate) &&
+            Objects.equals(this.registeredDateTime, projectResponse.registeredDateTime) &&
+            Objects.equals(this.tags, projectResponse.tags) &&
+            Objects.equals(this.client, projectResponse.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalModelTypeAnnotations/expected/src/gen/java/org/openapitools/model/UserRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalModelTypeAnnotations/expected/src/gen/java/org/openapitools/model/UserRequest.java
@@ -1,0 +1,149 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ登録・更新情報
+ */
+@JsonTypeName("UserRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:04.420411643+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+@jakarta.enterprise.context.SessionScoped
+@jakarta.enterprise.context.RequestScoped
+public class UserRequest   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserRequest firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserRequest lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     * minimum: 1
+     */
+    public UserRequest age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserRequest birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserRequest userRequest = (UserRequest) o;
+        return Objects.equals(this.firstName, userRequest.firstName) &&
+            Objects.equals(this.lastName, userRequest.lastName) &&
+            Objects.equals(this.age, userRequest.age) &&
+            Objects.equals(this.birthday, userRequest.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserRequest {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalModelTypeAnnotations/expected/src/gen/java/org/openapitools/model/UserResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/additionalModelTypeAnnotations/expected/src/gen/java/org/openapitools/model/UserResponse.java
@@ -1,0 +1,148 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ情報
+ */
+@JsonTypeName("UserResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:04.420411643+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+@jakarta.enterprise.context.SessionScoped
+@jakarta.enterprise.context.RequestScoped
+public class UserResponse   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserResponse firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserResponse lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     */
+    public UserResponse age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserResponse birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserResponse userResponse = (UserResponse) o;
+        return Objects.equals(this.firstName, userResponse.firstName) &&
+            Objects.equals(this.lastName, userResponse.lastName) &&
+            Objects.equals(this.age, userResponse.age) &&
+            Objects.equals(this.birthday, userResponse.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserResponse {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/apiAndModelPackage/expected/src/gen/java/com/example/someservice/api/ProjectsApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/apiAndModelPackage/expected/src/gen/java/com/example/someservice/api/ProjectsApi.java
@@ -1,0 +1,108 @@
+package com.example.someservice.api;
+
+import org.example.testservice.model.Client;
+import nablarch.fw.jaxrs.EntityResponse;
+import org.example.testservice.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.example.testservice.model.ProjectRequest;
+import org.example.testservice.model.ProjectResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/projects")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.613283926+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface ProjectsApi {
+    /**
+     * POST  : プロジェクトを作成する
+     *
+     * 情報を指定してプロジェクトを作成する
+     *
+     * @param projectRequest プロジェクト登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> createProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : プロジェクトを削除する
+     *
+     * IDを指定してプロジェクトを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project deleted
+     * @return not found project
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{projectId}/clients : プロジェクト内のクライアント一覧取得
+     *
+     * プロジェクト内のクライアント一覧を取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return プロジェクト内のクライアント一覧
+     */
+    @GET
+    @Path("/{projectId}/clients")
+    @Produces({ "application/json" })
+    EntityResponse<List<Client>> findAllClientsInProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのプロジェクトを取得する
+     *
+     * すべてのプロジェクトを取得する。タグとソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all projects
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<ProjectResponse>> findAllProjects(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : プロジェクトを取得する
+     *
+     * IDを指定してプロジェクトを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find project by id
+     * @return not found project
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> findProjectById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : プロジェクトを更新する
+     *
+     * IDを指定してプロジェクトを更新する
+     *
+     * @param projectRequest プロジェクト更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project updated
+     * @return request invalid
+     * @return not found project
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    HttpResponse updateProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/apiAndModelPackage/expected/src/gen/java/com/example/someservice/api/UsersApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/apiAndModelPackage/expected/src/gen/java/com/example/someservice/api/UsersApi.java
@@ -1,0 +1,92 @@
+package com.example.someservice.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import org.example.testservice.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.example.testservice.model.UserRequest;
+import org.example.testservice.model.UserResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/users")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.613283926+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface UsersApi {
+    /**
+     * POST  : ユーザを作成する
+     *
+     * 情報を指定してユーザを作成する
+     *
+     * @param userRequest ユーザ登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> createUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : ユーザを削除する
+     *
+     * IDを指定してユーザを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user deleted
+     * @return not found user
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteUser(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのユーザを取得する
+     *
+     * すべてのユーザを取得する。ソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all users
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<UserResponse>> findAllUsers(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : ユーザを取得する
+     *
+     * IDを指定してユーザを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find user by id
+     * @return not found user
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> findUserById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : ユーザを更新する
+     *
+     * IDを指定してユーザを更新する
+     *
+     * @param userRequest ユーザ更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user updated
+     * @return request invalid
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    HttpResponse updateUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/apiAndModelPackage/expected/src/gen/java/org/example/testservice/model/Client.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/apiAndModelPackage/expected/src/gen/java/org/example/testservice/model/Client.java
@@ -1,0 +1,102 @@
+package org.example.testservice.model;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * クライアント情報
+ */
+@JsonTypeName("Client")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.613283926+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class Client   {
+  private UUID id;
+  private String name;
+
+    /**
+     * クライアントID
+     */
+    public Client id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * クライアント名
+     */
+    public Client name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Client client = (Client) o;
+        return Objects.equals(this.id, client.id) &&
+            Objects.equals(this.name, client.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Client {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/apiAndModelPackage/expected/src/gen/java/org/example/testservice/model/ErrorResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/apiAndModelPackage/expected/src/gen/java/org/example/testservice/model/ErrorResponse.java
@@ -1,0 +1,79 @@
+package org.example.testservice.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * エラーレスポンス
+ */
+@JsonTypeName("ErrorResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.613283926+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ErrorResponse   {
+  private String message;
+
+    /**
+     * メッセージ
+     */
+    public ErrorResponse message(String message) {
+        this.message = message;
+        return this;
+    }
+
+    
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ErrorResponse errorResponse = (ErrorResponse) o;
+        return Objects.equals(this.message, errorResponse.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(message);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ErrorResponse {\n");
+        
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/apiAndModelPackage/expected/src/gen/java/org/example/testservice/model/ProjectRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/apiAndModelPackage/expected/src/gen/java/org/example/testservice/model/ProjectRequest.java
@@ -1,0 +1,256 @@
+package org.example.testservice.model;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.example.testservice.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト作成・更新情報
+ */
+@JsonTypeName("ProjectRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.613283926+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectRequest   {
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectRequest name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     * minimum: 1
+     */
+    public ProjectRequest sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     * minimum: 1
+     */
+    public ProjectRequest profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectRequest startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectRequest endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectRequest registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectRequest tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectRequest addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectRequest removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectRequest client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectRequest projectRequest = (ProjectRequest) o;
+        return Objects.equals(this.name, projectRequest.name) &&
+            Objects.equals(this.sales, projectRequest.sales) &&
+            Objects.equals(this.profit, projectRequest.profit) &&
+            Objects.equals(this.startDate, projectRequest.startDate) &&
+            Objects.equals(this.endDate, projectRequest.endDate) &&
+            Objects.equals(this.registeredDateTime, projectRequest.registeredDateTime) &&
+            Objects.equals(this.tags, projectRequest.tags) &&
+            Objects.equals(this.client, projectRequest.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectRequest {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/apiAndModelPackage/expected/src/gen/java/org/example/testservice/model/ProjectResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/apiAndModelPackage/expected/src/gen/java/org/example/testservice/model/ProjectResponse.java
@@ -1,0 +1,277 @@
+package org.example.testservice.model;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.example.testservice.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト情報
+ */
+@JsonTypeName("ProjectResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.613283926+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectResponse   {
+  private UUID id;
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクトID
+     */
+    public ProjectResponse id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectResponse name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     */
+    public ProjectResponse sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     */
+    public ProjectResponse profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectResponse startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectResponse endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectResponse registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectResponse tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectResponse addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectResponse removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectResponse client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectResponse projectResponse = (ProjectResponse) o;
+        return Objects.equals(this.id, projectResponse.id) &&
+            Objects.equals(this.name, projectResponse.name) &&
+            Objects.equals(this.sales, projectResponse.sales) &&
+            Objects.equals(this.profit, projectResponse.profit) &&
+            Objects.equals(this.startDate, projectResponse.startDate) &&
+            Objects.equals(this.endDate, projectResponse.endDate) &&
+            Objects.equals(this.registeredDateTime, projectResponse.registeredDateTime) &&
+            Objects.equals(this.tags, projectResponse.tags) &&
+            Objects.equals(this.client, projectResponse.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/apiAndModelPackage/expected/src/gen/java/org/example/testservice/model/UserRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/apiAndModelPackage/expected/src/gen/java/org/example/testservice/model/UserRequest.java
@@ -1,0 +1,147 @@
+package org.example.testservice.model;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ登録・更新情報
+ */
+@JsonTypeName("UserRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.613283926+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserRequest   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserRequest firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserRequest lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     * minimum: 1
+     */
+    public UserRequest age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserRequest birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserRequest userRequest = (UserRequest) o;
+        return Objects.equals(this.firstName, userRequest.firstName) &&
+            Objects.equals(this.lastName, userRequest.lastName) &&
+            Objects.equals(this.age, userRequest.age) &&
+            Objects.equals(this.birthday, userRequest.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserRequest {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/apiAndModelPackage/expected/src/gen/java/org/example/testservice/model/UserResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/apiAndModelPackage/expected/src/gen/java/org/example/testservice/model/UserResponse.java
@@ -1,0 +1,146 @@
+package org.example.testservice.model;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ情報
+ */
+@JsonTypeName("UserResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.613283926+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserResponse   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserResponse firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserResponse lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     */
+    public UserResponse age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserResponse birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserResponse userResponse = (UserResponse) o;
+        return Objects.equals(this.firstName, userResponse.firstName) &&
+            Objects.equals(this.lastName, userResponse.lastName) &&
+            Objects.equals(this.age, userResponse.age) &&
+            Objects.equals(this.birthday, userResponse.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserResponse {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/defaultOptions/expected/src/gen/java/org/openapitools/api/ProjectsApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/defaultOptions/expected/src/gen/java/org/openapitools/api/ProjectsApi.java
@@ -1,0 +1,108 @@
+package org.openapitools.api;
+
+import org.openapitools.model.Client;
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.ProjectRequest;
+import org.openapitools.model.ProjectResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/projects")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.827560677+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface ProjectsApi {
+    /**
+     * POST  : プロジェクトを作成する
+     *
+     * 情報を指定してプロジェクトを作成する
+     *
+     * @param projectRequest プロジェクト登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> createProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : プロジェクトを削除する
+     *
+     * IDを指定してプロジェクトを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project deleted
+     * @return not found project
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{projectId}/clients : プロジェクト内のクライアント一覧取得
+     *
+     * プロジェクト内のクライアント一覧を取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return プロジェクト内のクライアント一覧
+     */
+    @GET
+    @Path("/{projectId}/clients")
+    @Produces({ "application/json" })
+    EntityResponse<List<Client>> findAllClientsInProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのプロジェクトを取得する
+     *
+     * すべてのプロジェクトを取得する。タグとソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all projects
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<ProjectResponse>> findAllProjects(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : プロジェクトを取得する
+     *
+     * IDを指定してプロジェクトを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find project by id
+     * @return not found project
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> findProjectById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : プロジェクトを更新する
+     *
+     * IDを指定してプロジェクトを更新する
+     *
+     * @param projectRequest プロジェクト更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project updated
+     * @return request invalid
+     * @return not found project
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    HttpResponse updateProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/defaultOptions/expected/src/gen/java/org/openapitools/api/UsersApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/defaultOptions/expected/src/gen/java/org/openapitools/api/UsersApi.java
@@ -1,0 +1,92 @@
+package org.openapitools.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.UserRequest;
+import org.openapitools.model.UserResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/users")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.827560677+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface UsersApi {
+    /**
+     * POST  : ユーザを作成する
+     *
+     * 情報を指定してユーザを作成する
+     *
+     * @param userRequest ユーザ登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> createUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : ユーザを削除する
+     *
+     * IDを指定してユーザを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user deleted
+     * @return not found user
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteUser(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのユーザを取得する
+     *
+     * すべてのユーザを取得する。ソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all users
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<UserResponse>> findAllUsers(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : ユーザを取得する
+     *
+     * IDを指定してユーザを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find user by id
+     * @return not found user
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> findUserById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : ユーザを更新する
+     *
+     * IDを指定してユーザを更新する
+     *
+     * @param userRequest ユーザ更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user updated
+     * @return request invalid
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    HttpResponse updateUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/defaultOptions/expected/src/gen/java/org/openapitools/model/Client.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/defaultOptions/expected/src/gen/java/org/openapitools/model/Client.java
@@ -1,0 +1,102 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * クライアント情報
+ */
+@JsonTypeName("Client")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.827560677+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class Client   {
+  private UUID id;
+  private String name;
+
+    /**
+     * クライアントID
+     */
+    public Client id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * クライアント名
+     */
+    public Client name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Client client = (Client) o;
+        return Objects.equals(this.id, client.id) &&
+            Objects.equals(this.name, client.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Client {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/defaultOptions/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/defaultOptions/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
@@ -1,0 +1,79 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * エラーレスポンス
+ */
+@JsonTypeName("ErrorResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.827560677+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ErrorResponse   {
+  private String message;
+
+    /**
+     * メッセージ
+     */
+    public ErrorResponse message(String message) {
+        this.message = message;
+        return this;
+    }
+
+    
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ErrorResponse errorResponse = (ErrorResponse) o;
+        return Objects.equals(this.message, errorResponse.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(message);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ErrorResponse {\n");
+        
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/defaultOptions/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/defaultOptions/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
@@ -1,0 +1,256 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト作成・更新情報
+ */
+@JsonTypeName("ProjectRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.827560677+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectRequest   {
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectRequest name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     * minimum: 1
+     */
+    public ProjectRequest sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     * minimum: 1
+     */
+    public ProjectRequest profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectRequest startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectRequest endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectRequest registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectRequest tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectRequest addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectRequest removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectRequest client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectRequest projectRequest = (ProjectRequest) o;
+        return Objects.equals(this.name, projectRequest.name) &&
+            Objects.equals(this.sales, projectRequest.sales) &&
+            Objects.equals(this.profit, projectRequest.profit) &&
+            Objects.equals(this.startDate, projectRequest.startDate) &&
+            Objects.equals(this.endDate, projectRequest.endDate) &&
+            Objects.equals(this.registeredDateTime, projectRequest.registeredDateTime) &&
+            Objects.equals(this.tags, projectRequest.tags) &&
+            Objects.equals(this.client, projectRequest.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectRequest {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/defaultOptions/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/defaultOptions/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
@@ -1,0 +1,277 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト情報
+ */
+@JsonTypeName("ProjectResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.827560677+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectResponse   {
+  private UUID id;
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクトID
+     */
+    public ProjectResponse id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectResponse name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     */
+    public ProjectResponse sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     */
+    public ProjectResponse profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectResponse startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectResponse endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectResponse registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectResponse tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectResponse addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectResponse removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectResponse client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectResponse projectResponse = (ProjectResponse) o;
+        return Objects.equals(this.id, projectResponse.id) &&
+            Objects.equals(this.name, projectResponse.name) &&
+            Objects.equals(this.sales, projectResponse.sales) &&
+            Objects.equals(this.profit, projectResponse.profit) &&
+            Objects.equals(this.startDate, projectResponse.startDate) &&
+            Objects.equals(this.endDate, projectResponse.endDate) &&
+            Objects.equals(this.registeredDateTime, projectResponse.registeredDateTime) &&
+            Objects.equals(this.tags, projectResponse.tags) &&
+            Objects.equals(this.client, projectResponse.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/defaultOptions/expected/src/gen/java/org/openapitools/model/UserRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/defaultOptions/expected/src/gen/java/org/openapitools/model/UserRequest.java
@@ -1,0 +1,147 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ登録・更新情報
+ */
+@JsonTypeName("UserRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.827560677+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserRequest   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserRequest firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserRequest lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     * minimum: 1
+     */
+    public UserRequest age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserRequest birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserRequest userRequest = (UserRequest) o;
+        return Objects.equals(this.firstName, userRequest.firstName) &&
+            Objects.equals(this.lastName, userRequest.lastName) &&
+            Objects.equals(this.age, userRequest.age) &&
+            Objects.equals(this.birthday, userRequest.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserRequest {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/defaultOptions/expected/src/gen/java/org/openapitools/model/UserResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/defaultOptions/expected/src/gen/java/org/openapitools/model/UserResponse.java
@@ -1,0 +1,146 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ情報
+ */
+@JsonTypeName("UserResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.827560677+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserResponse   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserResponse firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserResponse lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     */
+    public UserResponse age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserResponse birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserResponse userResponse = (UserResponse) o;
+        return Objects.equals(this.firstName, userResponse.firstName) &&
+            Objects.equals(this.lastName, userResponse.lastName) &&
+            Objects.equals(this.age, userResponse.age) &&
+            Objects.equals(this.birthday, userResponse.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserResponse {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/generateBuilders/expected/src/gen/java/org/openapitools/api/ProjectsApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/generateBuilders/expected/src/gen/java/org/openapitools/api/ProjectsApi.java
@@ -1,0 +1,108 @@
+package org.openapitools.api;
+
+import org.openapitools.model.Client;
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.ProjectRequest;
+import org.openapitools.model.ProjectResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/projects")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.173255034+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface ProjectsApi {
+    /**
+     * POST  : プロジェクトを作成する
+     *
+     * 情報を指定してプロジェクトを作成する
+     *
+     * @param projectRequest プロジェクト登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> createProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : プロジェクトを削除する
+     *
+     * IDを指定してプロジェクトを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project deleted
+     * @return not found project
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{projectId}/clients : プロジェクト内のクライアント一覧取得
+     *
+     * プロジェクト内のクライアント一覧を取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return プロジェクト内のクライアント一覧
+     */
+    @GET
+    @Path("/{projectId}/clients")
+    @Produces({ "application/json" })
+    EntityResponse<List<Client>> findAllClientsInProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのプロジェクトを取得する
+     *
+     * すべてのプロジェクトを取得する。タグとソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all projects
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<ProjectResponse>> findAllProjects(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : プロジェクトを取得する
+     *
+     * IDを指定してプロジェクトを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find project by id
+     * @return not found project
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> findProjectById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : プロジェクトを更新する
+     *
+     * IDを指定してプロジェクトを更新する
+     *
+     * @param projectRequest プロジェクト更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project updated
+     * @return request invalid
+     * @return not found project
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    HttpResponse updateProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/generateBuilders/expected/src/gen/java/org/openapitools/api/UsersApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/generateBuilders/expected/src/gen/java/org/openapitools/api/UsersApi.java
@@ -1,0 +1,92 @@
+package org.openapitools.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.UserRequest;
+import org.openapitools.model.UserResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/users")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.173255034+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface UsersApi {
+    /**
+     * POST  : ユーザを作成する
+     *
+     * 情報を指定してユーザを作成する
+     *
+     * @param userRequest ユーザ登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> createUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : ユーザを削除する
+     *
+     * IDを指定してユーザを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user deleted
+     * @return not found user
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteUser(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのユーザを取得する
+     *
+     * すべてのユーザを取得する。ソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all users
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<UserResponse>> findAllUsers(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : ユーザを取得する
+     *
+     * IDを指定してユーザを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find user by id
+     * @return not found user
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> findUserById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : ユーザを更新する
+     *
+     * IDを指定してユーザを更新する
+     *
+     * @param userRequest ユーザ更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user updated
+     * @return request invalid
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    HttpResponse updateUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/generateBuilders/expected/src/gen/java/org/openapitools/model/Client.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/generateBuilders/expected/src/gen/java/org/openapitools/model/Client.java
@@ -1,0 +1,143 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * クライアント情報
+ */
+@JsonTypeName("Client")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.173255034+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class Client   {
+  private UUID id;
+  private String name;
+
+    protected Client(ClientBuilder<?, ?> b) {
+        this.id = b.id;
+        this.name = b.name;
+    }
+
+    public Client() {
+    }
+
+    /**
+     * クライアントID
+     */
+    public Client id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * クライアント名
+     */
+    public Client name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Client client = (Client) o;
+        return Objects.equals(this.id, client.id) &&
+            Objects.equals(this.name, client.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Client {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+    public static ClientBuilder<?, ?> builder() {
+        return new ClientBuilderImpl();
+    }
+
+    private static class ClientBuilderImpl extends ClientBuilder<Client, ClientBuilderImpl> {
+
+    @Override
+    protected ClientBuilderImpl self() {
+        return this;
+    }
+
+    @Override
+    public Client build() {
+        return new Client(this);
+    }
+  }
+
+    public static abstract class ClientBuilder<C extends Client, B extends ClientBuilder<C, B>>  {
+        private UUID id;
+        private String name;
+        protected abstract B self();
+
+        public abstract C build();
+
+        public B id(UUID id) {
+            this.id = id;
+            return self();
+        }
+        public B name(String name) {
+            this.name = name;
+            return self();
+        }
+    }
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/generateBuilders/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/generateBuilders/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
@@ -1,0 +1,114 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * エラーレスポンス
+ */
+@JsonTypeName("ErrorResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.173255034+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ErrorResponse   {
+  private String message;
+
+    protected ErrorResponse(ErrorResponseBuilder<?, ?> b) {
+        this.message = b.message;
+    }
+
+    public ErrorResponse() {
+    }
+
+    /**
+     * メッセージ
+     */
+    public ErrorResponse message(String message) {
+        this.message = message;
+        return this;
+    }
+
+    
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ErrorResponse errorResponse = (ErrorResponse) o;
+        return Objects.equals(this.message, errorResponse.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(message);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ErrorResponse {\n");
+        
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+    public static ErrorResponseBuilder<?, ?> builder() {
+        return new ErrorResponseBuilderImpl();
+    }
+
+    private static class ErrorResponseBuilderImpl extends ErrorResponseBuilder<ErrorResponse, ErrorResponseBuilderImpl> {
+
+    @Override
+    protected ErrorResponseBuilderImpl self() {
+        return this;
+    }
+
+    @Override
+    public ErrorResponse build() {
+        return new ErrorResponse(this);
+    }
+  }
+
+    public static abstract class ErrorResponseBuilder<C extends ErrorResponse, B extends ErrorResponseBuilder<C, B>>  {
+        private String message;
+        protected abstract B self();
+
+        public abstract C build();
+
+        public B message(String message) {
+            this.message = message;
+            return self();
+        }
+    }
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/generateBuilders/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/generateBuilders/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
@@ -1,0 +1,333 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト作成・更新情報
+ */
+@JsonTypeName("ProjectRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.173255034+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectRequest   {
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    protected ProjectRequest(ProjectRequestBuilder<?, ?> b) {
+        this.name = b.name;
+        this.sales = b.sales;
+        this.profit = b.profit;
+        this.startDate = b.startDate;
+        this.endDate = b.endDate;
+        this.registeredDateTime = b.registeredDateTime;
+        this.tags = b.tags;
+        this.client = b.client;
+    }
+
+    public ProjectRequest() {
+    }
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectRequest name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     * minimum: 1
+     */
+    public ProjectRequest sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     * minimum: 1
+     */
+    public ProjectRequest profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectRequest startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectRequest endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectRequest registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectRequest tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectRequest addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectRequest removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectRequest client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectRequest projectRequest = (ProjectRequest) o;
+        return Objects.equals(this.name, projectRequest.name) &&
+            Objects.equals(this.sales, projectRequest.sales) &&
+            Objects.equals(this.profit, projectRequest.profit) &&
+            Objects.equals(this.startDate, projectRequest.startDate) &&
+            Objects.equals(this.endDate, projectRequest.endDate) &&
+            Objects.equals(this.registeredDateTime, projectRequest.registeredDateTime) &&
+            Objects.equals(this.tags, projectRequest.tags) &&
+            Objects.equals(this.client, projectRequest.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectRequest {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+    public static ProjectRequestBuilder<?, ?> builder() {
+        return new ProjectRequestBuilderImpl();
+    }
+
+    private static class ProjectRequestBuilderImpl extends ProjectRequestBuilder<ProjectRequest, ProjectRequestBuilderImpl> {
+
+    @Override
+    protected ProjectRequestBuilderImpl self() {
+        return this;
+    }
+
+    @Override
+    public ProjectRequest build() {
+        return new ProjectRequest(this);
+    }
+  }
+
+    public static abstract class ProjectRequestBuilder<C extends ProjectRequest, B extends ProjectRequestBuilder<C, B>>  {
+        private String name;
+        private Long sales;
+        private Integer profit;
+        private LocalDate startDate;
+        private LocalDate endDate;
+        private OffsetDateTime registeredDateTime;
+        private List<String> tags = new ArrayList<>();
+        private Client client;
+        protected abstract B self();
+
+        public abstract C build();
+
+        public B name(String name) {
+            this.name = name;
+            return self();
+        }
+        public B sales(Long sales) {
+            this.sales = sales;
+            return self();
+        }
+        public B profit(Integer profit) {
+            this.profit = profit;
+            return self();
+        }
+        public B startDate(LocalDate startDate) {
+            this.startDate = startDate;
+            return self();
+        }
+        public B endDate(LocalDate endDate) {
+            this.endDate = endDate;
+            return self();
+        }
+        public B registeredDateTime(OffsetDateTime registeredDateTime) {
+            this.registeredDateTime = registeredDateTime;
+            return self();
+        }
+        public B tags(List<String> tags) {
+            this.tags = tags;
+            return self();
+        }
+        public B client(Client client) {
+            this.client = client;
+            return self();
+        }
+    }
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/generateBuilders/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/generateBuilders/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
@@ -1,0 +1,360 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト情報
+ */
+@JsonTypeName("ProjectResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.173255034+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectResponse   {
+  private UUID id;
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    protected ProjectResponse(ProjectResponseBuilder<?, ?> b) {
+        this.id = b.id;
+        this.name = b.name;
+        this.sales = b.sales;
+        this.profit = b.profit;
+        this.startDate = b.startDate;
+        this.endDate = b.endDate;
+        this.registeredDateTime = b.registeredDateTime;
+        this.tags = b.tags;
+        this.client = b.client;
+    }
+
+    public ProjectResponse() {
+    }
+
+    /**
+     * プロジェクトID
+     */
+    public ProjectResponse id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectResponse name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     */
+    public ProjectResponse sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     */
+    public ProjectResponse profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectResponse startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectResponse endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectResponse registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectResponse tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectResponse addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectResponse removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectResponse client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectResponse projectResponse = (ProjectResponse) o;
+        return Objects.equals(this.id, projectResponse.id) &&
+            Objects.equals(this.name, projectResponse.name) &&
+            Objects.equals(this.sales, projectResponse.sales) &&
+            Objects.equals(this.profit, projectResponse.profit) &&
+            Objects.equals(this.startDate, projectResponse.startDate) &&
+            Objects.equals(this.endDate, projectResponse.endDate) &&
+            Objects.equals(this.registeredDateTime, projectResponse.registeredDateTime) &&
+            Objects.equals(this.tags, projectResponse.tags) &&
+            Objects.equals(this.client, projectResponse.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+    public static ProjectResponseBuilder<?, ?> builder() {
+        return new ProjectResponseBuilderImpl();
+    }
+
+    private static class ProjectResponseBuilderImpl extends ProjectResponseBuilder<ProjectResponse, ProjectResponseBuilderImpl> {
+
+    @Override
+    protected ProjectResponseBuilderImpl self() {
+        return this;
+    }
+
+    @Override
+    public ProjectResponse build() {
+        return new ProjectResponse(this);
+    }
+  }
+
+    public static abstract class ProjectResponseBuilder<C extends ProjectResponse, B extends ProjectResponseBuilder<C, B>>  {
+        private UUID id;
+        private String name;
+        private Long sales;
+        private Integer profit;
+        private LocalDate startDate;
+        private LocalDate endDate;
+        private OffsetDateTime registeredDateTime;
+        private List<String> tags = new ArrayList<>();
+        private Client client;
+        protected abstract B self();
+
+        public abstract C build();
+
+        public B id(UUID id) {
+            this.id = id;
+            return self();
+        }
+        public B name(String name) {
+            this.name = name;
+            return self();
+        }
+        public B sales(Long sales) {
+            this.sales = sales;
+            return self();
+        }
+        public B profit(Integer profit) {
+            this.profit = profit;
+            return self();
+        }
+        public B startDate(LocalDate startDate) {
+            this.startDate = startDate;
+            return self();
+        }
+        public B endDate(LocalDate endDate) {
+            this.endDate = endDate;
+            return self();
+        }
+        public B registeredDateTime(OffsetDateTime registeredDateTime) {
+            this.registeredDateTime = registeredDateTime;
+            return self();
+        }
+        public B tags(List<String> tags) {
+            this.tags = tags;
+            return self();
+        }
+        public B client(Client client) {
+            this.client = client;
+            return self();
+        }
+    }
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/generateBuilders/expected/src/gen/java/org/openapitools/model/UserRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/generateBuilders/expected/src/gen/java/org/openapitools/model/UserRequest.java
@@ -1,0 +1,200 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ登録・更新情報
+ */
+@JsonTypeName("UserRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.173255034+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserRequest   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    protected UserRequest(UserRequestBuilder<?, ?> b) {
+        this.firstName = b.firstName;
+        this.lastName = b.lastName;
+        this.age = b.age;
+        this.birthday = b.birthday;
+    }
+
+    public UserRequest() {
+    }
+
+    /**
+     * 名
+     */
+    public UserRequest firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserRequest lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     * minimum: 1
+     */
+    public UserRequest age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserRequest birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserRequest userRequest = (UserRequest) o;
+        return Objects.equals(this.firstName, userRequest.firstName) &&
+            Objects.equals(this.lastName, userRequest.lastName) &&
+            Objects.equals(this.age, userRequest.age) &&
+            Objects.equals(this.birthday, userRequest.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserRequest {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+    public static UserRequestBuilder<?, ?> builder() {
+        return new UserRequestBuilderImpl();
+    }
+
+    private static class UserRequestBuilderImpl extends UserRequestBuilder<UserRequest, UserRequestBuilderImpl> {
+
+    @Override
+    protected UserRequestBuilderImpl self() {
+        return this;
+    }
+
+    @Override
+    public UserRequest build() {
+        return new UserRequest(this);
+    }
+  }
+
+    public static abstract class UserRequestBuilder<C extends UserRequest, B extends UserRequestBuilder<C, B>>  {
+        private String firstName;
+        private String lastName;
+        private Integer age;
+        private LocalDate birthday;
+        protected abstract B self();
+
+        public abstract C build();
+
+        public B firstName(String firstName) {
+            this.firstName = firstName;
+            return self();
+        }
+        public B lastName(String lastName) {
+            this.lastName = lastName;
+            return self();
+        }
+        public B age(Integer age) {
+            this.age = age;
+            return self();
+        }
+        public B birthday(LocalDate birthday) {
+            this.birthday = birthday;
+            return self();
+        }
+    }
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/generateBuilders/expected/src/gen/java/org/openapitools/model/UserResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/generateBuilders/expected/src/gen/java/org/openapitools/model/UserResponse.java
@@ -1,0 +1,199 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ情報
+ */
+@JsonTypeName("UserResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:06.173255034+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserResponse   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    protected UserResponse(UserResponseBuilder<?, ?> b) {
+        this.firstName = b.firstName;
+        this.lastName = b.lastName;
+        this.age = b.age;
+        this.birthday = b.birthday;
+    }
+
+    public UserResponse() {
+    }
+
+    /**
+     * 名
+     */
+    public UserResponse firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserResponse lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     */
+    public UserResponse age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserResponse birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserResponse userResponse = (UserResponse) o;
+        return Objects.equals(this.firstName, userResponse.firstName) &&
+            Objects.equals(this.lastName, userResponse.lastName) &&
+            Objects.equals(this.age, userResponse.age) &&
+            Objects.equals(this.birthday, userResponse.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserResponse {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+    public static UserResponseBuilder<?, ?> builder() {
+        return new UserResponseBuilderImpl();
+    }
+
+    private static class UserResponseBuilderImpl extends UserResponseBuilder<UserResponse, UserResponseBuilderImpl> {
+
+    @Override
+    protected UserResponseBuilderImpl self() {
+        return this;
+    }
+
+    @Override
+    public UserResponse build() {
+        return new UserResponse(this);
+    }
+  }
+
+    public static abstract class UserResponseBuilder<C extends UserResponse, B extends UserResponseBuilder<C, B>>  {
+        private String firstName;
+        private String lastName;
+        private Integer age;
+        private LocalDate birthday;
+        protected abstract B self();
+
+        public abstract C build();
+
+        public B firstName(String firstName) {
+            this.firstName = firstName;
+            return self();
+        }
+        public B lastName(String lastName) {
+            this.lastName = lastName;
+            return self();
+        }
+        public B age(Integer age) {
+            this.age = age;
+            return self();
+        }
+        public B birthday(LocalDate birthday) {
+            this.birthday = birthday;
+            return self();
+        }
+    }
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/hideGenerationTimestamp/expected/src/gen/java/org/openapitools/api/ProjectsApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/hideGenerationTimestamp/expected/src/gen/java/org/openapitools/api/ProjectsApi.java
@@ -1,0 +1,108 @@
+package org.openapitools.api;
+
+import org.openapitools.model.Client;
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.ProjectRequest;
+import org.openapitools.model.ProjectResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/projects")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", comments = "Generator version: 7.10.0")
+public interface ProjectsApi {
+    /**
+     * POST  : プロジェクトを作成する
+     *
+     * 情報を指定してプロジェクトを作成する
+     *
+     * @param projectRequest プロジェクト登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> createProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : プロジェクトを削除する
+     *
+     * IDを指定してプロジェクトを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project deleted
+     * @return not found project
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{projectId}/clients : プロジェクト内のクライアント一覧取得
+     *
+     * プロジェクト内のクライアント一覧を取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return プロジェクト内のクライアント一覧
+     */
+    @GET
+    @Path("/{projectId}/clients")
+    @Produces({ "application/json" })
+    EntityResponse<List<Client>> findAllClientsInProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのプロジェクトを取得する
+     *
+     * すべてのプロジェクトを取得する。タグとソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all projects
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<ProjectResponse>> findAllProjects(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : プロジェクトを取得する
+     *
+     * IDを指定してプロジェクトを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find project by id
+     * @return not found project
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> findProjectById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : プロジェクトを更新する
+     *
+     * IDを指定してプロジェクトを更新する
+     *
+     * @param projectRequest プロジェクト更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project updated
+     * @return request invalid
+     * @return not found project
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    HttpResponse updateProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/hideGenerationTimestamp/expected/src/gen/java/org/openapitools/api/UsersApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/hideGenerationTimestamp/expected/src/gen/java/org/openapitools/api/UsersApi.java
@@ -1,0 +1,92 @@
+package org.openapitools.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.UserRequest;
+import org.openapitools.model.UserResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/users")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", comments = "Generator version: 7.10.0")
+public interface UsersApi {
+    /**
+     * POST  : ユーザを作成する
+     *
+     * 情報を指定してユーザを作成する
+     *
+     * @param userRequest ユーザ登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> createUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : ユーザを削除する
+     *
+     * IDを指定してユーザを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user deleted
+     * @return not found user
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteUser(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのユーザを取得する
+     *
+     * すべてのユーザを取得する。ソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all users
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<UserResponse>> findAllUsers(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : ユーザを取得する
+     *
+     * IDを指定してユーザを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find user by id
+     * @return not found user
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> findUserById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : ユーザを更新する
+     *
+     * IDを指定してユーザを更新する
+     *
+     * @param userRequest ユーザ更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user updated
+     * @return request invalid
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    HttpResponse updateUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/hideGenerationTimestamp/expected/src/gen/java/org/openapitools/model/Client.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/hideGenerationTimestamp/expected/src/gen/java/org/openapitools/model/Client.java
@@ -1,0 +1,102 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * クライアント情報
+ */
+@JsonTypeName("Client")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", comments = "Generator version: 7.10.0")
+public class Client   {
+  private UUID id;
+  private String name;
+
+    /**
+     * クライアントID
+     */
+    public Client id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * クライアント名
+     */
+    public Client name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Client client = (Client) o;
+        return Objects.equals(this.id, client.id) &&
+            Objects.equals(this.name, client.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Client {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/hideGenerationTimestamp/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/hideGenerationTimestamp/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
@@ -1,0 +1,79 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * エラーレスポンス
+ */
+@JsonTypeName("ErrorResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", comments = "Generator version: 7.10.0")
+public class ErrorResponse   {
+  private String message;
+
+    /**
+     * メッセージ
+     */
+    public ErrorResponse message(String message) {
+        this.message = message;
+        return this;
+    }
+
+    
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ErrorResponse errorResponse = (ErrorResponse) o;
+        return Objects.equals(this.message, errorResponse.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(message);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ErrorResponse {\n");
+        
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/hideGenerationTimestamp/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/hideGenerationTimestamp/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
@@ -1,0 +1,256 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト作成・更新情報
+ */
+@JsonTypeName("ProjectRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", comments = "Generator version: 7.10.0")
+public class ProjectRequest   {
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectRequest name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     * minimum: 1
+     */
+    public ProjectRequest sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     * minimum: 1
+     */
+    public ProjectRequest profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectRequest startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectRequest endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectRequest registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectRequest tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectRequest addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectRequest removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectRequest client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectRequest projectRequest = (ProjectRequest) o;
+        return Objects.equals(this.name, projectRequest.name) &&
+            Objects.equals(this.sales, projectRequest.sales) &&
+            Objects.equals(this.profit, projectRequest.profit) &&
+            Objects.equals(this.startDate, projectRequest.startDate) &&
+            Objects.equals(this.endDate, projectRequest.endDate) &&
+            Objects.equals(this.registeredDateTime, projectRequest.registeredDateTime) &&
+            Objects.equals(this.tags, projectRequest.tags) &&
+            Objects.equals(this.client, projectRequest.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectRequest {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/hideGenerationTimestamp/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/hideGenerationTimestamp/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
@@ -1,0 +1,277 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト情報
+ */
+@JsonTypeName("ProjectResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", comments = "Generator version: 7.10.0")
+public class ProjectResponse   {
+  private UUID id;
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクトID
+     */
+    public ProjectResponse id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectResponse name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     */
+    public ProjectResponse sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     */
+    public ProjectResponse profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectResponse startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectResponse endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectResponse registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectResponse tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectResponse addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectResponse removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectResponse client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectResponse projectResponse = (ProjectResponse) o;
+        return Objects.equals(this.id, projectResponse.id) &&
+            Objects.equals(this.name, projectResponse.name) &&
+            Objects.equals(this.sales, projectResponse.sales) &&
+            Objects.equals(this.profit, projectResponse.profit) &&
+            Objects.equals(this.startDate, projectResponse.startDate) &&
+            Objects.equals(this.endDate, projectResponse.endDate) &&
+            Objects.equals(this.registeredDateTime, projectResponse.registeredDateTime) &&
+            Objects.equals(this.tags, projectResponse.tags) &&
+            Objects.equals(this.client, projectResponse.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/hideGenerationTimestamp/expected/src/gen/java/org/openapitools/model/UserRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/hideGenerationTimestamp/expected/src/gen/java/org/openapitools/model/UserRequest.java
@@ -1,0 +1,147 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ登録・更新情報
+ */
+@JsonTypeName("UserRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", comments = "Generator version: 7.10.0")
+public class UserRequest   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserRequest firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserRequest lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     * minimum: 1
+     */
+    public UserRequest age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserRequest birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserRequest userRequest = (UserRequest) o;
+        return Objects.equals(this.firstName, userRequest.firstName) &&
+            Objects.equals(this.lastName, userRequest.lastName) &&
+            Objects.equals(this.age, userRequest.age) &&
+            Objects.equals(this.birthday, userRequest.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserRequest {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/hideGenerationTimestamp/expected/src/gen/java/org/openapitools/model/UserResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/hideGenerationTimestamp/expected/src/gen/java/org/openapitools/model/UserResponse.java
@@ -1,0 +1,146 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ情報
+ */
+@JsonTypeName("UserResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", comments = "Generator version: 7.10.0")
+public class UserResponse   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserResponse firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserResponse lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     */
+    public UserResponse age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserResponse birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserResponse userResponse = (UserResponse) o;
+        return Objects.equals(this.firstName, userResponse.firstName) &&
+            Objects.equals(this.lastName, userResponse.lastName) &&
+            Objects.equals(this.age, userResponse.age) &&
+            Objects.equals(this.birthday, userResponse.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserResponse {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/primitivePropertiesAsString/expected/src/gen/java/org/openapitools/api/ProjectsApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/primitivePropertiesAsString/expected/src/gen/java/org/openapitools/api/ProjectsApi.java
@@ -1,0 +1,108 @@
+package org.openapitools.api;
+
+import org.openapitools.model.Client;
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.ProjectRequest;
+import org.openapitools.model.ProjectResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/projects")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:04.981051647+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface ProjectsApi {
+    /**
+     * POST  : プロジェクトを作成する
+     *
+     * 情報を指定してプロジェクトを作成する
+     *
+     * @param projectRequest プロジェクト登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> createProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : プロジェクトを削除する
+     *
+     * IDを指定してプロジェクトを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project deleted
+     * @return not found project
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{projectId}/clients : プロジェクト内のクライアント一覧取得
+     *
+     * プロジェクト内のクライアント一覧を取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return プロジェクト内のクライアント一覧
+     */
+    @GET
+    @Path("/{projectId}/clients")
+    @Produces({ "application/json" })
+    EntityResponse<List<Client>> findAllClientsInProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのプロジェクトを取得する
+     *
+     * すべてのプロジェクトを取得する。タグとソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all projects
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<ProjectResponse>> findAllProjects(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : プロジェクトを取得する
+     *
+     * IDを指定してプロジェクトを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find project by id
+     * @return not found project
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> findProjectById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : プロジェクトを更新する
+     *
+     * IDを指定してプロジェクトを更新する
+     *
+     * @param projectRequest プロジェクト更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project updated
+     * @return request invalid
+     * @return not found project
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    HttpResponse updateProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/primitivePropertiesAsString/expected/src/gen/java/org/openapitools/api/UsersApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/primitivePropertiesAsString/expected/src/gen/java/org/openapitools/api/UsersApi.java
@@ -1,0 +1,92 @@
+package org.openapitools.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.UserRequest;
+import org.openapitools.model.UserResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/users")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:04.981051647+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface UsersApi {
+    /**
+     * POST  : ユーザを作成する
+     *
+     * 情報を指定してユーザを作成する
+     *
+     * @param userRequest ユーザ登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> createUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : ユーザを削除する
+     *
+     * IDを指定してユーザを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user deleted
+     * @return not found user
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteUser(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのユーザを取得する
+     *
+     * すべてのユーザを取得する。ソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all users
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<UserResponse>> findAllUsers(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : ユーザを取得する
+     *
+     * IDを指定してユーザを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find user by id
+     * @return not found user
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> findUserById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : ユーザを更新する
+     *
+     * IDを指定してユーザを更新する
+     *
+     * @param userRequest ユーザ更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user updated
+     * @return request invalid
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    HttpResponse updateUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/primitivePropertiesAsString/expected/src/gen/java/org/openapitools/model/Client.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/primitivePropertiesAsString/expected/src/gen/java/org/openapitools/model/Client.java
@@ -1,0 +1,155 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * クライアント情報
+ */
+@JsonTypeName("Client")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:04.981051647+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class Client   {
+  private String id;
+  private String name;
+  public enum StatusEnum {
+
+    ACTIVE(String.valueOf("active")), INACTIVE(String.valueOf("inactive"));
+
+
+    private String value;
+
+    StatusEnum (String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static StatusEnum fromValue(String value) {
+        for (StatusEnum b : StatusEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+  private StatusEnum status;
+
+    /**
+     * クライアントID
+     */
+    public Client id(String id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * クライアント名
+     */
+    public Client name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Client Status
+     */
+    public Client status(StatusEnum status) {
+        this.status = status;
+        return this;
+    }
+
+    
+    @JsonProperty("status")
+    public StatusEnum getStatus() {
+        return status;
+    }
+
+    @JsonProperty("status")
+    public void setStatus(StatusEnum status) {
+        this.status = status;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Client client = (Client) o;
+        return Objects.equals(this.id, client.id) &&
+            Objects.equals(this.name, client.name) &&
+            Objects.equals(this.status, client.status);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, status);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Client {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/primitivePropertiesAsString/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/primitivePropertiesAsString/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
@@ -1,0 +1,79 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * エラーレスポンス
+ */
+@JsonTypeName("ErrorResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:04.981051647+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ErrorResponse   {
+  private String message;
+
+    /**
+     * メッセージ
+     */
+    public ErrorResponse message(String message) {
+        this.message = message;
+        return this;
+    }
+
+    
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ErrorResponse errorResponse = (ErrorResponse) o;
+        return Objects.equals(this.message, errorResponse.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(message);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ErrorResponse {\n");
+        
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/primitivePropertiesAsString/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/primitivePropertiesAsString/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
@@ -1,0 +1,254 @@
+package org.openapitools.model;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト作成・更新情報
+ */
+@JsonTypeName("ProjectRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:04.981051647+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectRequest   {
+  private String name;
+  private String sales;
+  private String profit;
+  private String startDate;
+  private String endDate;
+  private String registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectRequest name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     * minimum: 1
+     */
+    public ProjectRequest sales(String sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public String getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(String sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     * minimum: 1
+     */
+    public ProjectRequest profit(String profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public String getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(String profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectRequest startDate(String startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public String getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(String startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectRequest endDate(String endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public String getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(String endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectRequest registeredDateTime(String registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public String getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(String registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectRequest tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectRequest addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectRequest removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectRequest client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectRequest projectRequest = (ProjectRequest) o;
+        return Objects.equals(this.name, projectRequest.name) &&
+            Objects.equals(this.sales, projectRequest.sales) &&
+            Objects.equals(this.profit, projectRequest.profit) &&
+            Objects.equals(this.startDate, projectRequest.startDate) &&
+            Objects.equals(this.endDate, projectRequest.endDate) &&
+            Objects.equals(this.registeredDateTime, projectRequest.registeredDateTime) &&
+            Objects.equals(this.tags, projectRequest.tags) &&
+            Objects.equals(this.client, projectRequest.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectRequest {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/primitivePropertiesAsString/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/primitivePropertiesAsString/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
@@ -1,0 +1,274 @@
+package org.openapitools.model;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト情報
+ */
+@JsonTypeName("ProjectResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:04.981051647+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectResponse   {
+  private String id;
+  private String name;
+  private String sales;
+  private String profit;
+  private String startDate;
+  private String endDate;
+  private String registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクトID
+     */
+    public ProjectResponse id(String id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectResponse name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     */
+    public ProjectResponse sales(String sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public String getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(String sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     */
+    public ProjectResponse profit(String profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public String getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(String profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectResponse startDate(String startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public String getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(String startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectResponse endDate(String endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public String getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(String endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectResponse registeredDateTime(String registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public String getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(String registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectResponse tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectResponse addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectResponse removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectResponse client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectResponse projectResponse = (ProjectResponse) o;
+        return Objects.equals(this.id, projectResponse.id) &&
+            Objects.equals(this.name, projectResponse.name) &&
+            Objects.equals(this.sales, projectResponse.sales) &&
+            Objects.equals(this.profit, projectResponse.profit) &&
+            Objects.equals(this.startDate, projectResponse.startDate) &&
+            Objects.equals(this.endDate, projectResponse.endDate) &&
+            Objects.equals(this.registeredDateTime, projectResponse.registeredDateTime) &&
+            Objects.equals(this.tags, projectResponse.tags) &&
+            Objects.equals(this.client, projectResponse.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/primitivePropertiesAsString/expected/src/gen/java/org/openapitools/model/UserRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/primitivePropertiesAsString/expected/src/gen/java/org/openapitools/model/UserRequest.java
@@ -1,0 +1,146 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ登録・更新情報
+ */
+@JsonTypeName("UserRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:04.981051647+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserRequest   {
+  private String firstName;
+  private String lastName;
+  private String age;
+  private String birthday;
+
+    /**
+     * 名
+     */
+    public UserRequest firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserRequest lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     * minimum: 1
+     */
+    public UserRequest age(String age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public String getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(String age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserRequest birthday(String birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public String getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(String birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserRequest userRequest = (UserRequest) o;
+        return Objects.equals(this.firstName, userRequest.firstName) &&
+            Objects.equals(this.lastName, userRequest.lastName) &&
+            Objects.equals(this.age, userRequest.age) &&
+            Objects.equals(this.birthday, userRequest.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserRequest {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/primitivePropertiesAsString/expected/src/gen/java/org/openapitools/model/UserResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/primitivePropertiesAsString/expected/src/gen/java/org/openapitools/model/UserResponse.java
@@ -1,0 +1,145 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ情報
+ */
+@JsonTypeName("UserResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:04.981051647+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserResponse   {
+  private String firstName;
+  private String lastName;
+  private String age;
+  private String birthday;
+
+    /**
+     * 名
+     */
+    public UserResponse firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserResponse lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     */
+    public UserResponse age(String age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public String getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(String age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserResponse birthday(String birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public String getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(String birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserResponse userResponse = (UserResponse) o;
+        return Objects.equals(this.firstName, userResponse.firstName) &&
+            Objects.equals(this.lastName, userResponse.lastName) &&
+            Objects.equals(this.age, userResponse.age) &&
+            Objects.equals(this.birthday, userResponse.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserResponse {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/projects.yaml
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/projects.yaml
@@ -1,0 +1,435 @@
+---
+openapi: 3.0.3
+info:
+  title: OpenAPI API Sample
+  version: 0.0.1
+servers:
+- url: http://localhost:8080
+  description: OpenAPI API Sample description
+tags:
+- name: clientRead
+- name: projectRead
+- name: projectWrite
+- name: userRead
+- name: userWrite
+paths:
+  /projects:
+    get:
+      tags:
+      - projectRead
+      summary: すべてのプロジェクトを取得する
+      description: すべてのプロジェクトを取得する。タグとソート順を指定できる
+      operationId: findAllProjects
+      parameters:
+      - name: sortBy
+        in: query
+        description: ソート条件
+        schema:
+          type: string
+      - name: tag
+        in: query
+        description: タグ
+        schema:
+          type: string
+      responses:
+        "200":
+          description: find all projects
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProjectResponse'
+    post:
+      tags:
+      - projectWrite
+      summary: プロジェクトを作成する
+      description: 情報を指定してプロジェクトを作成する
+      operationId: createProject
+      requestBody:
+        description: プロジェクト登録情報
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectRequest'
+      responses:
+        "200":
+          description: project created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResponse'
+        "400":
+          description: request invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /projects/{id}:
+    get:
+      tags:
+      - projectRead
+      summary: プロジェクトを取得する
+      description: IDを指定してプロジェクトを取得する
+      operationId: findProjectById
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: find project by id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResponse'
+        "404":
+          description: not found project
+    put:
+      tags:
+      - projectWrite
+      summary: プロジェクトを更新する
+      description: IDを指定してプロジェクトを更新する
+      operationId: updateProject
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: プロジェクト更新情報
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectRequest'
+      responses:
+        "204":
+          description: project updated
+        "400":
+          description: request invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: not found project
+    delete:
+      tags:
+      - projectWrite
+      summary: プロジェクトを削除する
+      description: IDを指定してプロジェクトを削除する
+      operationId: deleteProject
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: project deleted
+        "404":
+          description: not found project
+  /projects/{projectId}/clients:
+    get:
+      tags:
+      - clientRead
+      summary: プロジェクト内のクライアント一覧取得
+      description: プロジェクト内のクライアント一覧を取得する
+      operationId: findAllClientsInProject
+      parameters:
+      - name: projectId
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: プロジェクト内のクライアント一覧
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Client'
+  /users:
+    get:
+      tags:
+      - userRead
+      summary: すべてのユーザを取得する
+      description: すべてのユーザを取得する。ソート順を指定できる
+      operationId: findAllUsers
+      parameters:
+      - name: sortBy
+        in: query
+        description: ソート条件
+        schema:
+          type: string
+      responses:
+        "200":
+          description: find all users
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserResponse'
+    post:
+      tags:
+      - userWrite
+      summary: ユーザを作成する
+      description: 情報を指定してユーザを作成する
+      operationId: createUser
+      requestBody:
+        description: ユーザ登録情報
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserRequest'
+      responses:
+        "200":
+          description: user created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        "400":
+          description: request invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /users/{id}:
+    get:
+      tags:
+      - userRead
+      summary: ユーザを取得する
+      description: IDを指定してユーザを取得する
+      operationId: findUserById
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: find user by id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        "404":
+          description: not found user
+    put:
+      tags:
+      - userWrite
+      summary: ユーザを更新する
+      description: IDを指定してユーザを更新する
+      operationId: updateUser
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: ユーザ更新情報
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserRequest'
+      responses:
+        "204":
+          description: user updated
+        "400":
+          description: request invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+      - userWrite
+      summary: ユーザを削除する
+      description: IDを指定してユーザを削除する
+      operationId: deleteUser
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: user deleted
+        "404":
+          description: not found user
+components:
+  schemas:
+    Client:
+      description: クライアント情報
+      type: object
+      properties:
+        id:
+          format: uuid
+          description: クライアントID
+          pattern: "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+          type: string
+        name:
+          description: クライアント名
+          type: string
+    ErrorResponse:
+      description: エラーレスポンス
+      type: object
+      properties:
+        message:
+          description: メッセージ
+          type: string
+    ProjectRequest:
+      description: プロジェクト作成・更新情報
+      required:
+      - name
+      - startDate
+      - client
+      type: object
+      properties:
+        name:
+          description: プロジェクト名
+          maxLength: 100
+          minLength: 1
+          type: string
+        sales:
+          format: int64
+          description: 売上
+          minimum: 1
+          type: integer
+        profit:
+          format: int32
+          description: 利益
+          minimum: 1
+          type: integer
+        startDate:
+          format: date
+          description: 開始日
+          type: string
+          example: 2022-03-10
+        endDate:
+          format: date
+          description: 終了日
+          type: string
+          example: 2022-03-10
+        registeredDateTime:
+          format: date-time
+          description: 登録日時
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        tags:
+          description: タグ
+          maxItems: 5
+          type: array
+          items:
+            type: string
+        client:
+          description: クライアント情報
+          type: object
+          allOf:
+          - $ref: '#/components/schemas/Client'
+    ProjectResponse:
+      description: プロジェクト情報
+      type: object
+      properties:
+        id:
+          format: uuid
+          description: プロジェクトID
+          pattern: "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+          type: string
+        name:
+          description: プロジェクト名
+          type: string
+        sales:
+          format: int64
+          description: 売上
+          type: integer
+        profit:
+          format: int32
+          description: 利益
+          type: integer
+        startDate:
+          format: date
+          description: 開始日
+          type: string
+          example: 2022-03-10
+        endDate:
+          format: date
+          description: 終了日
+          type: string
+          example: 2022-03-10
+        registeredDateTime:
+          format: date-time
+          description: 登録日時
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        tags:
+          description: タグ
+          type: array
+          items:
+            type: string
+        client:
+          description: クライアント情報
+          type: object
+          allOf:
+          - $ref: '#/components/schemas/Client'
+    UserRequest:
+      description: ユーザ登録・更新情報
+      required:
+      - firstName
+      - lastName
+      type: object
+      properties:
+        firstName:
+          description: 名
+          minLength: 1
+          type: string
+        lastName:
+          description: 姓
+          minLength: 1
+          type: string
+        age:
+          format: int32
+          description: 年齢
+          minimum: 1
+          type: integer
+        birthday:
+          format: date
+          description: 誕生日
+          type: string
+          example: 2022-03-10
+    UserResponse:
+      description: ユーザ情報
+      type: object
+      properties:
+        firstName:
+          description: 名
+          type: string
+        lastName:
+          description: 姓
+          type: string
+        age:
+          format: int32
+          description: 年齢
+          type: integer
+        birthday:
+          format: date
+          description: 誕生日
+          type: string
+          example: 2022-03-10

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/projects_consumes_media_types.yaml
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/projects_consumes_media_types.yaml
@@ -1,0 +1,447 @@
+---
+openapi: 3.0.3
+info:
+  title: OpenAPI API Sample
+  version: 0.0.1
+servers:
+- url: http://localhost:8080
+  description: OpenAPI API Sample description
+tags:
+- name: clientRead
+- name: projectRead
+- name: projectWrite
+- name: userRead
+- name: userWrite
+paths:
+  /projects:
+    get:
+      tags:
+      - projectRead
+      summary: すべてのプロジェクトを取得する
+      description: すべてのプロジェクトを取得する。タグとソート順を指定できる
+      operationId: findAllProjects
+      parameters:
+      - name: sortBy
+        in: query
+        description: ソート条件
+        schema:
+          type: string
+      - name: tag
+        in: query
+        description: タグ
+        schema:
+          type: string
+      responses:
+        "200":
+          description: find all projects
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProjectResponse'
+    post:
+      tags:
+      - projectWrite
+      summary: プロジェクトを作成する
+      description: 情報を指定してプロジェクトを作成する
+      operationId: createProject
+      requestBody:
+        description: プロジェクト登録情報
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectRequest'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/ProjectRequest'
+      responses:
+        "200":
+          description: project created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResponse'
+        "400":
+          description: request invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /projects/{id}:
+    get:
+      tags:
+      - projectRead
+      summary: プロジェクトを取得する
+      description: IDを指定してプロジェクトを取得する
+      operationId: findProjectById
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: find project by id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResponse'
+        "404":
+          description: not found project
+    put:
+      tags:
+      - projectWrite
+      summary: プロジェクトを更新する
+      description: IDを指定してプロジェクトを更新する
+      operationId: updateProject
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: プロジェクト更新情報
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectRequest'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/ProjectRequest'
+      responses:
+        "204":
+          description: project updated
+        "400":
+          description: request invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: not found project
+    delete:
+      tags:
+      - projectWrite
+      summary: プロジェクトを削除する
+      description: IDを指定してプロジェクトを削除する
+      operationId: deleteProject
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: project deleted
+        "404":
+          description: not found project
+  /projects/{projectId}/clients:
+    get:
+      tags:
+      - clientRead
+      summary: プロジェクト内のクライアント一覧取得
+      description: プロジェクト内のクライアント一覧を取得する
+      operationId: findAllClientsInProject
+      parameters:
+      - name: projectId
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: プロジェクト内のクライアント一覧
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Client'
+  /users:
+    get:
+      tags:
+      - userRead
+      summary: すべてのユーザを取得する
+      description: すべてのユーザを取得する。ソート順を指定できる
+      operationId: findAllUsers
+      parameters:
+      - name: sortBy
+        in: query
+        description: ソート条件
+        schema:
+          type: string
+      responses:
+        "200":
+          description: find all users
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserResponse'
+    post:
+      tags:
+      - userWrite
+      summary: ユーザを作成する
+      description: 情報を指定してユーザを作成する
+      operationId: createUser
+      requestBody:
+        description: ユーザ登録情報
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserRequest'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/UserRequest'
+      responses:
+        "200":
+          description: user created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        "400":
+          description: request invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /users/{id}:
+    get:
+      tags:
+      - userRead
+      summary: ユーザを取得する
+      description: IDを指定してユーザを取得する
+      operationId: findUserById
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: find user by id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        "404":
+          description: not found user
+    put:
+      tags:
+      - userWrite
+      summary: ユーザを更新する
+      description: IDを指定してユーザを更新する
+      operationId: updateUser
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: ユーザ更新情報
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserRequest'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/UserRequest'
+      responses:
+        "204":
+          description: user updated
+        "400":
+          description: request invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+      - userWrite
+      summary: ユーザを削除する
+      description: IDを指定してユーザを削除する
+      operationId: deleteUser
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: user deleted
+        "404":
+          description: not found user
+components:
+  schemas:
+    Client:
+      description: クライアント情報
+      type: object
+      properties:
+        id:
+          format: uuid
+          description: クライアントID
+          pattern: "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+          type: string
+        name:
+          description: クライアント名
+          type: string
+    ErrorResponse:
+      description: エラーレスポンス
+      type: object
+      properties:
+        message:
+          description: メッセージ
+          type: string
+    ProjectRequest:
+      description: プロジェクト作成・更新情報
+      required:
+      - name
+      - startDate
+      - client
+      type: object
+      properties:
+        name:
+          description: プロジェクト名
+          maxLength: 100
+          minLength: 1
+          type: string
+        sales:
+          format: int64
+          description: 売上
+          minimum: 1
+          type: integer
+        profit:
+          format: int32
+          description: 利益
+          minimum: 1
+          type: integer
+        startDate:
+          format: date
+          description: 開始日
+          type: string
+          example: 2022-03-10
+        endDate:
+          format: date
+          description: 終了日
+          type: string
+          example: 2022-03-10
+        registeredDateTime:
+          format: date-time
+          description: 登録日時
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        tags:
+          description: タグ
+          maxItems: 5
+          type: array
+          items:
+            type: string
+        client:
+          description: クライアント情報
+          type: object
+          allOf:
+          - $ref: '#/components/schemas/Client'
+    ProjectResponse:
+      description: プロジェクト情報
+      type: object
+      properties:
+        id:
+          format: uuid
+          description: プロジェクトID
+          pattern: "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+          type: string
+        name:
+          description: プロジェクト名
+          type: string
+        sales:
+          format: int64
+          description: 売上
+          type: integer
+        profit:
+          format: int32
+          description: 利益
+          type: integer
+        startDate:
+          format: date
+          description: 開始日
+          type: string
+          example: 2022-03-10
+        endDate:
+          format: date
+          description: 終了日
+          type: string
+          example: 2022-03-10
+        registeredDateTime:
+          format: date-time
+          description: 登録日時
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        tags:
+          description: タグ
+          type: array
+          items:
+            type: string
+        client:
+          description: クライアント情報
+          type: object
+          allOf:
+          - $ref: '#/components/schemas/Client'
+    UserRequest:
+      description: ユーザ登録・更新情報
+      required:
+      - firstName
+      - lastName
+      type: object
+      properties:
+        firstName:
+          description: 名
+          minLength: 1
+          type: string
+        lastName:
+          description: 姓
+          minLength: 1
+          type: string
+        age:
+          format: int32
+          description: 年齢
+          minimum: 1
+          type: integer
+        birthday:
+          format: date
+          description: 誕生日
+          type: string
+          example: 2022-03-10
+    UserResponse:
+      description: ユーザ情報
+      type: object
+      properties:
+        firstName:
+          description: 名
+          type: string
+        lastName:
+          description: 姓
+          type: string
+        age:
+          format: int32
+          description: 年齢
+          type: integer
+        birthday:
+          format: date
+          description: 誕生日
+          type: string
+          example: 2022-03-10

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/projects_multiple_tags.yaml
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/projects_multiple_tags.yaml
@@ -1,0 +1,448 @@
+---
+openapi: 3.0.3
+info:
+  title: OpenAPI API Sample
+  version: 0.0.1
+servers:
+- url: http://localhost:8080
+  description: OpenAPI API Sample description
+tags:
+- name: read
+- name: write
+- name: clientRead
+- name: projectRead
+- name: projectWrite
+- name: userRead
+- name: userWrite
+paths:
+  /projects:
+    get:
+      tags:
+      - read
+      - projectRead
+      summary: すべてのプロジェクトを取得する
+      description: すべてのプロジェクトを取得する。タグとソート順を指定できる
+      operationId: findAllProjects
+      parameters:
+      - name: sortBy
+        in: query
+        description: ソート条件
+        schema:
+          type: string
+      - name: tag
+        in: query
+        description: タグ
+        schema:
+          type: string
+      responses:
+        "200":
+          description: find all projects
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProjectResponse'
+    post:
+      tags:
+      - write
+      - projectWrite
+      summary: プロジェクトを作成する
+      description: 情報を指定してプロジェクトを作成する
+      operationId: createProject
+      requestBody:
+        description: プロジェクト登録情報
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectRequest'
+      responses:
+        "200":
+          description: project created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResponse'
+        "400":
+          description: request invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /projects/{id}:
+    get:
+      tags:
+      - read
+      - projectRead
+      summary: プロジェクトを取得する
+      description: IDを指定してプロジェクトを取得する
+      operationId: findProjectById
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: find project by id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResponse'
+        "404":
+          description: not found project
+    put:
+      tags:
+      - write
+      - projectWrite
+      summary: プロジェクトを更新する
+      description: IDを指定してプロジェクトを更新する
+      operationId: updateProject
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: プロジェクト更新情報
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectRequest'
+      responses:
+        "204":
+          description: project updated
+        "400":
+          description: request invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: not found project
+    delete:
+      tags:
+      - write
+      - projectWrite
+      summary: プロジェクトを削除する
+      description: IDを指定してプロジェクトを削除する
+      operationId: deleteProject
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: project deleted
+        "404":
+          description: not found project
+  /projects/{projectId}/clients:
+    get:
+      tags:
+      - read
+      - clientRead
+      summary: プロジェクト内のクライアント一覧取得
+      description: プロジェクト内のクライアント一覧を取得する
+      operationId: findAllClientsInProject
+      parameters:
+      - name: projectId
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: プロジェクト内のクライアント一覧
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Client'
+  /users:
+    get:
+      tags:
+      - read
+      - userRead
+      summary: すべてのユーザを取得する
+      description: すべてのユーザを取得する。ソート順を指定できる
+      operationId: findAllUsers
+      parameters:
+      - name: sortBy
+        in: query
+        description: ソート条件
+        schema:
+          type: string
+      responses:
+        "200":
+          description: find all users
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserResponse'
+    post:
+      tags:
+      - write
+      - userWrite
+      summary: ユーザを作成する
+      description: 情報を指定してユーザを作成する
+      operationId: createUser
+      requestBody:
+        description: ユーザ登録情報
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserRequest'
+      responses:
+        "200":
+          description: user created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        "400":
+          description: request invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /users/{id}:
+    get:
+      tags:
+      - read
+      - userRead
+      summary: ユーザを取得する
+      description: IDを指定してユーザを取得する
+      operationId: findUserById
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: find user by id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        "404":
+          description: not found user
+    put:
+      tags:
+      - write
+      - userWrite
+      summary: ユーザを更新する
+      description: IDを指定してユーザを更新する
+      operationId: updateUser
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: ユーザ更新情報
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserRequest'
+      responses:
+        "204":
+          description: user updated
+        "400":
+          description: request invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+      - write
+      - userWrite
+      summary: ユーザを削除する
+      description: IDを指定してユーザを削除する
+      operationId: deleteUser
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: user deleted
+        "404":
+          description: not found user
+components:
+  schemas:
+    Client:
+      description: クライアント情報
+      type: object
+      properties:
+        id:
+          format: uuid
+          description: クライアントID
+          pattern: "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+          type: string
+        name:
+          description: クライアント名
+          type: string
+    ErrorResponse:
+      description: エラーレスポンス
+      type: object
+      properties:
+        message:
+          description: メッセージ
+          type: string
+    ProjectRequest:
+      description: プロジェクト作成・更新情報
+      required:
+      - name
+      - startDate
+      - client
+      type: object
+      properties:
+        name:
+          description: プロジェクト名
+          maxLength: 100
+          minLength: 1
+          type: string
+        sales:
+          format: int64
+          description: 売上
+          minimum: 1
+          type: integer
+        profit:
+          format: int32
+          description: 利益
+          minimum: 1
+          type: integer
+        startDate:
+          format: date
+          description: 開始日
+          type: string
+          example: 2022-03-10
+        endDate:
+          format: date
+          description: 終了日
+          type: string
+          example: 2022-03-10
+        registeredDateTime:
+          format: date-time
+          description: 登録日時
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        tags:
+          description: タグ
+          maxItems: 5
+          type: array
+          items:
+            type: string
+        client:
+          description: クライアント情報
+          type: object
+          allOf:
+          - $ref: '#/components/schemas/Client'
+    ProjectResponse:
+      description: プロジェクト情報
+      type: object
+      properties:
+        id:
+          format: uuid
+          description: プロジェクトID
+          pattern: "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+          type: string
+        name:
+          description: プロジェクト名
+          type: string
+        sales:
+          format: int64
+          description: 売上
+          type: integer
+        profit:
+          format: int32
+          description: 利益
+          type: integer
+        startDate:
+          format: date
+          description: 開始日
+          type: string
+          example: 2022-03-10
+        endDate:
+          format: date
+          description: 終了日
+          type: string
+          example: 2022-03-10
+        registeredDateTime:
+          format: date-time
+          description: 登録日時
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        tags:
+          description: タグ
+          type: array
+          items:
+            type: string
+        client:
+          description: クライアント情報
+          type: object
+          allOf:
+          - $ref: '#/components/schemas/Client'
+    UserRequest:
+      description: ユーザ登録・更新情報
+      required:
+      - firstName
+      - lastName
+      type: object
+      properties:
+        firstName:
+          description: 名
+          minLength: 1
+          type: string
+        lastName:
+          description: 姓
+          minLength: 1
+          type: string
+        age:
+          format: int32
+          description: 年齢
+          minimum: 1
+          type: integer
+        birthday:
+          format: date
+          description: 誕生日
+          type: string
+          example: 2022-03-10
+    UserResponse:
+      description: ユーザ情報
+      type: object
+      properties:
+        firstName:
+          description: 名
+          type: string
+        lastName:
+          description: 姓
+          type: string
+        age:
+          format: int32
+          description: 年齢
+          type: integer
+        birthday:
+          format: date
+          description: 誕生日
+          type: string
+          example: 2022-03-10

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/projects_produces_media_types.yaml
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/projects_produces_media_types.yaml
@@ -1,0 +1,474 @@
+---
+openapi: 3.0.3
+info:
+  title: OpenAPI API Sample
+  version: 0.0.1
+servers:
+- url: http://localhost:8080
+  description: OpenAPI API Sample description
+tags:
+- name: clientRead
+- name: projectRead
+- name: projectWrite
+- name: userRead
+- name: userWrite
+paths:
+  /projects:
+    get:
+      tags:
+      - projectRead
+      summary: すべてのプロジェクトを取得する
+      description: すべてのプロジェクトを取得する。タグとソート順を指定できる
+      operationId: findAllProjects
+      parameters:
+      - name: sortBy
+        in: query
+        description: ソート条件
+        schema:
+          type: string
+      - name: tag
+        in: query
+        description: タグ
+        schema:
+          type: string
+      responses:
+        "200":
+          description: find all projects
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProjectResponse'
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProjectResponse'
+    post:
+      tags:
+      - projectWrite
+      summary: プロジェクトを作成する
+      description: 情報を指定してプロジェクトを作成する
+      operationId: createProject
+      requestBody:
+        description: プロジェクト登録情報
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectRequest'
+      responses:
+        "200":
+          description: project created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResponse'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ProjectResponse'
+        "400":
+          description: request invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /projects/{id}:
+    get:
+      tags:
+      - projectRead
+      summary: プロジェクトを取得する
+      description: IDを指定してプロジェクトを取得する
+      operationId: findProjectById
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: find project by id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResponse'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ProjectResponse'
+        "404":
+          description: not found project
+    put:
+      tags:
+      - projectWrite
+      summary: プロジェクトを更新する
+      description: IDを指定してプロジェクトを更新する
+      operationId: updateProject
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: プロジェクト更新情報
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectRequest'
+      responses:
+        "204":
+          description: project updated
+        "400":
+          description: request invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: not found project
+    delete:
+      tags:
+      - projectWrite
+      summary: プロジェクトを削除する
+      description: IDを指定してプロジェクトを削除する
+      operationId: deleteProject
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: project deleted
+        "404":
+          description: not found project
+  /projects/{projectId}/clients:
+    get:
+      tags:
+      - clientRead
+      summary: プロジェクト内のクライアント一覧取得
+      description: プロジェクト内のクライアント一覧を取得する
+      operationId: findAllClientsInProject
+      parameters:
+      - name: projectId
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: プロジェクト内のクライアント一覧
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Client'
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Client'
+  /users:
+    get:
+      tags:
+      - userRead
+      summary: すべてのユーザを取得する
+      description: すべてのユーザを取得する。ソート順を指定できる
+      operationId: findAllUsers
+      parameters:
+      - name: sortBy
+        in: query
+        description: ソート条件
+        schema:
+          type: string
+      responses:
+        "200":
+          description: find all users
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserResponse'
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserResponse'
+    post:
+      tags:
+      - userWrite
+      summary: ユーザを作成する
+      description: 情報を指定してユーザを作成する
+      operationId: createUser
+      requestBody:
+        description: ユーザ登録情報
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserRequest'
+      responses:
+        "200":
+          description: user created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        "400":
+          description: request invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /users/{id}:
+    get:
+      tags:
+      - userRead
+      summary: ユーザを取得する
+      description: IDを指定してユーザを取得する
+      operationId: findUserById
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: find user by id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        "404":
+          description: not found user
+    put:
+      tags:
+      - userWrite
+      summary: ユーザを更新する
+      description: IDを指定してユーザを更新する
+      operationId: updateUser
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: ユーザ更新情報
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserRequest'
+      responses:
+        "204":
+          description: user updated
+        "400":
+          description: request invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+      - userWrite
+      summary: ユーザを削除する
+      description: IDを指定してユーザを削除する
+      operationId: deleteUser
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: user deleted
+        "404":
+          description: not found user
+components:
+  schemas:
+    Client:
+      description: クライアント情報
+      type: object
+      properties:
+        id:
+          format: uuid
+          description: クライアントID
+          pattern: "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+          type: string
+        name:
+          description: クライアント名
+          type: string
+    ErrorResponse:
+      description: エラーレスポンス
+      type: object
+      properties:
+        message:
+          description: メッセージ
+          type: string
+    ProjectRequest:
+      description: プロジェクト作成・更新情報
+      required:
+      - name
+      - startDate
+      - client
+      type: object
+      properties:
+        name:
+          description: プロジェクト名
+          maxLength: 100
+          minLength: 1
+          type: string
+        sales:
+          format: int64
+          description: 売上
+          minimum: 1
+          type: integer
+        profit:
+          format: int32
+          description: 利益
+          minimum: 1
+          type: integer
+        startDate:
+          format: date
+          description: 開始日
+          type: string
+          example: 2022-03-10
+        endDate:
+          format: date
+          description: 終了日
+          type: string
+          example: 2022-03-10
+        registeredDateTime:
+          format: date-time
+          description: 登録日時
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        tags:
+          description: タグ
+          maxItems: 5
+          type: array
+          items:
+            type: string
+        client:
+          description: クライアント情報
+          type: object
+          allOf:
+          - $ref: '#/components/schemas/Client'
+    ProjectResponse:
+      description: プロジェクト情報
+      type: object
+      properties:
+        id:
+          format: uuid
+          description: プロジェクトID
+          pattern: "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+          type: string
+        name:
+          description: プロジェクト名
+          type: string
+        sales:
+          format: int64
+          description: 売上
+          type: integer
+        profit:
+          format: int32
+          description: 利益
+          type: integer
+        startDate:
+          format: date
+          description: 開始日
+          type: string
+          example: 2022-03-10
+        endDate:
+          format: date
+          description: 終了日
+          type: string
+          example: 2022-03-10
+        registeredDateTime:
+          format: date-time
+          description: 登録日時
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        tags:
+          description: タグ
+          type: array
+          items:
+            type: string
+        client:
+          description: クライアント情報
+          type: object
+          allOf:
+          - $ref: '#/components/schemas/Client'
+    UserRequest:
+      description: ユーザ登録・更新情報
+      required:
+      - firstName
+      - lastName
+      type: object
+      properties:
+        firstName:
+          description: 名
+          minLength: 1
+          type: string
+        lastName:
+          description: 姓
+          minLength: 1
+          type: string
+        age:
+          format: int32
+          description: 年齢
+          minimum: 1
+          type: integer
+        birthday:
+          format: date
+          description: 誕生日
+          type: string
+          example: 2022-03-10
+    UserResponse:
+      description: ユーザ情報
+      type: object
+      properties:
+        firstName:
+          description: 名
+          type: string
+        lastName:
+          description: 姓
+          type: string
+        age:
+          format: int32
+          description: 年齢
+          type: integer
+        birthday:
+          format: date
+          description: 誕生日
+          type: string
+          example: 2022-03-10

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/projects_with_enum.yaml
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/projects_with_enum.yaml
@@ -1,0 +1,441 @@
+---
+openapi: 3.0.3
+info:
+  title: OpenAPI API Sample
+  version: 0.0.1
+servers:
+- url: http://localhost:8080
+  description: OpenAPI API Sample description
+tags:
+- name: clientRead
+- name: projectRead
+- name: projectWrite
+- name: userRead
+- name: userWrite
+paths:
+  /projects:
+    get:
+      tags:
+      - projectRead
+      summary: すべてのプロジェクトを取得する
+      description: すべてのプロジェクトを取得する。タグとソート順を指定できる
+      operationId: findAllProjects
+      parameters:
+      - name: sortBy
+        in: query
+        description: ソート条件
+        schema:
+          type: string
+      - name: tag
+        in: query
+        description: タグ
+        schema:
+          type: string
+      responses:
+        "200":
+          description: find all projects
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProjectResponse'
+    post:
+      tags:
+      - projectWrite
+      summary: プロジェクトを作成する
+      description: 情報を指定してプロジェクトを作成する
+      operationId: createProject
+      requestBody:
+        description: プロジェクト登録情報
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectRequest'
+      responses:
+        "200":
+          description: project created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResponse'
+        "400":
+          description: request invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /projects/{id}:
+    get:
+      tags:
+      - projectRead
+      summary: プロジェクトを取得する
+      description: IDを指定してプロジェクトを取得する
+      operationId: findProjectById
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: find project by id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResponse'
+        "404":
+          description: not found project
+    put:
+      tags:
+      - projectWrite
+      summary: プロジェクトを更新する
+      description: IDを指定してプロジェクトを更新する
+      operationId: updateProject
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: プロジェクト更新情報
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectRequest'
+      responses:
+        "204":
+          description: project updated
+        "400":
+          description: request invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: not found project
+    delete:
+      tags:
+      - projectWrite
+      summary: プロジェクトを削除する
+      description: IDを指定してプロジェクトを削除する
+      operationId: deleteProject
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: project deleted
+        "404":
+          description: not found project
+  /projects/{projectId}/clients:
+    get:
+      tags:
+      - clientRead
+      summary: プロジェクト内のクライアント一覧取得
+      description: プロジェクト内のクライアント一覧を取得する
+      operationId: findAllClientsInProject
+      parameters:
+      - name: projectId
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: プロジェクト内のクライアント一覧
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Client'
+  /users:
+    get:
+      tags:
+      - userRead
+      summary: すべてのユーザを取得する
+      description: すべてのユーザを取得する。ソート順を指定できる
+      operationId: findAllUsers
+      parameters:
+      - name: sortBy
+        in: query
+        description: ソート条件
+        schema:
+          type: string
+      responses:
+        "200":
+          description: find all users
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserResponse'
+    post:
+      tags:
+      - userWrite
+      summary: ユーザを作成する
+      description: 情報を指定してユーザを作成する
+      operationId: createUser
+      requestBody:
+        description: ユーザ登録情報
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserRequest'
+      responses:
+        "200":
+          description: user created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        "400":
+          description: request invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /users/{id}:
+    get:
+      tags:
+      - userRead
+      summary: ユーザを取得する
+      description: IDを指定してユーザを取得する
+      operationId: findUserById
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: find user by id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        "404":
+          description: not found user
+    put:
+      tags:
+      - userWrite
+      summary: ユーザを更新する
+      description: IDを指定してユーザを更新する
+      operationId: updateUser
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: ユーザ更新情報
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserRequest'
+      responses:
+        "204":
+          description: user updated
+        "400":
+          description: request invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+      - userWrite
+      summary: ユーザを削除する
+      description: IDを指定してユーザを削除する
+      operationId: deleteUser
+      parameters:
+      - name: id
+        in: path
+        description: ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: user deleted
+        "404":
+          description: not found user
+components:
+  schemas:
+    Client:
+      description: クライアント情報
+      type: object
+      properties:
+        id:
+          format: uuid
+          description: クライアントID
+          pattern: "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+          type: string
+        name:
+          description: クライアント名
+          type: string
+        status:
+          type: string
+          description: Client Status
+          enum:
+            - active
+            - inactive
+    ErrorResponse:
+      description: エラーレスポンス
+      type: object
+      properties:
+        message:
+          description: メッセージ
+          type: string
+    ProjectRequest:
+      description: プロジェクト作成・更新情報
+      required:
+      - name
+      - startDate
+      - client
+      type: object
+      properties:
+        name:
+          description: プロジェクト名
+          maxLength: 100
+          minLength: 1
+          type: string
+        sales:
+          format: int64
+          description: 売上
+          minimum: 1
+          type: integer
+        profit:
+          format: int32
+          description: 利益
+          minimum: 1
+          type: integer
+        startDate:
+          format: date
+          description: 開始日
+          type: string
+          example: 2022-03-10
+        endDate:
+          format: date
+          description: 終了日
+          type: string
+          example: 2022-03-10
+        registeredDateTime:
+          format: date-time
+          description: 登録日時
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        tags:
+          description: タグ
+          maxItems: 5
+          type: array
+          items:
+            type: string
+        client:
+          description: クライアント情報
+          type: object
+          allOf:
+          - $ref: '#/components/schemas/Client'
+    ProjectResponse:
+      description: プロジェクト情報
+      type: object
+      properties:
+        id:
+          format: uuid
+          description: プロジェクトID
+          pattern: "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+          type: string
+        name:
+          description: プロジェクト名
+          type: string
+        sales:
+          format: int64
+          description: 売上
+          type: integer
+        profit:
+          format: int32
+          description: 利益
+          type: integer
+        startDate:
+          format: date
+          description: 開始日
+          type: string
+          example: 2022-03-10
+        endDate:
+          format: date
+          description: 終了日
+          type: string
+          example: 2022-03-10
+        registeredDateTime:
+          format: date-time
+          description: 登録日時
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        tags:
+          description: タグ
+          type: array
+          items:
+            type: string
+        client:
+          description: クライアント情報
+          type: object
+          allOf:
+          - $ref: '#/components/schemas/Client'
+    UserRequest:
+      description: ユーザ登録・更新情報
+      required:
+      - firstName
+      - lastName
+      type: object
+      properties:
+        firstName:
+          description: 名
+          minLength: 1
+          type: string
+        lastName:
+          description: 姓
+          minLength: 1
+          type: string
+        age:
+          format: int32
+          description: 年齢
+          minimum: 1
+          type: integer
+        birthday:
+          format: date
+          description: 誕生日
+          type: string
+          example: 2022-03-10
+    UserResponse:
+      description: ユーザ情報
+      type: object
+      properties:
+        firstName:
+          description: 名
+          type: string
+        lastName:
+          description: 姓
+          type: string
+        age:
+          format: int32
+          description: 年齢
+          type: integer
+        birthday:
+          format: date
+          description: 誕生日
+          type: string
+          example: 2022-03-10

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/serializableModel/expected/src/gen/java/org/openapitools/api/ProjectsApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/serializableModel/expected/src/gen/java/org/openapitools/api/ProjectsApi.java
@@ -1,0 +1,108 @@
+package org.openapitools.api;
+
+import org.openapitools.model.Client;
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.ProjectRequest;
+import org.openapitools.model.ProjectResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/projects")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:05.399151358+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface ProjectsApi {
+    /**
+     * POST  : プロジェクトを作成する
+     *
+     * 情報を指定してプロジェクトを作成する
+     *
+     * @param projectRequest プロジェクト登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> createProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : プロジェクトを削除する
+     *
+     * IDを指定してプロジェクトを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project deleted
+     * @return not found project
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{projectId}/clients : プロジェクト内のクライアント一覧取得
+     *
+     * プロジェクト内のクライアント一覧を取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return プロジェクト内のクライアント一覧
+     */
+    @GET
+    @Path("/{projectId}/clients")
+    @Produces({ "application/json" })
+    EntityResponse<List<Client>> findAllClientsInProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのプロジェクトを取得する
+     *
+     * すべてのプロジェクトを取得する。タグとソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all projects
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<ProjectResponse>> findAllProjects(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : プロジェクトを取得する
+     *
+     * IDを指定してプロジェクトを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find project by id
+     * @return not found project
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> findProjectById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : プロジェクトを更新する
+     *
+     * IDを指定してプロジェクトを更新する
+     *
+     * @param projectRequest プロジェクト更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project updated
+     * @return request invalid
+     * @return not found project
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    HttpResponse updateProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/serializableModel/expected/src/gen/java/org/openapitools/api/UsersApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/serializableModel/expected/src/gen/java/org/openapitools/api/UsersApi.java
@@ -1,0 +1,92 @@
+package org.openapitools.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.UserRequest;
+import org.openapitools.model.UserResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/users")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:05.399151358+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface UsersApi {
+    /**
+     * POST  : ユーザを作成する
+     *
+     * 情報を指定してユーザを作成する
+     *
+     * @param userRequest ユーザ登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> createUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : ユーザを削除する
+     *
+     * IDを指定してユーザを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user deleted
+     * @return not found user
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteUser(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのユーザを取得する
+     *
+     * すべてのユーザを取得する。ソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all users
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<UserResponse>> findAllUsers(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : ユーザを取得する
+     *
+     * IDを指定してユーザを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find user by id
+     * @return not found user
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> findUserById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : ユーザを更新する
+     *
+     * IDを指定してユーザを更新する
+     *
+     * @param userRequest ユーザ更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user updated
+     * @return request invalid
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    HttpResponse updateUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/serializableModel/expected/src/gen/java/org/openapitools/model/Client.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/serializableModel/expected/src/gen/java/org/openapitools/model/Client.java
@@ -1,0 +1,103 @@
+package org.openapitools.model;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.UUID;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * クライアント情報
+ */
+@JsonTypeName("Client")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:05.399151358+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class Client  implements Serializable {
+  private UUID id;
+  private String name;
+
+    /**
+     * クライアントID
+     */
+    public Client id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * クライアント名
+     */
+    public Client name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Client client = (Client) o;
+        return Objects.equals(this.id, client.id) &&
+            Objects.equals(this.name, client.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Client {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/serializableModel/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/serializableModel/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
@@ -1,0 +1,80 @@
+package org.openapitools.model;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * エラーレスポンス
+ */
+@JsonTypeName("ErrorResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:05.399151358+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ErrorResponse  implements Serializable {
+  private String message;
+
+    /**
+     * メッセージ
+     */
+    public ErrorResponse message(String message) {
+        this.message = message;
+        return this;
+    }
+
+    
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ErrorResponse errorResponse = (ErrorResponse) o;
+        return Objects.equals(this.message, errorResponse.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(message);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ErrorResponse {\n");
+        
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/serializableModel/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/serializableModel/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
@@ -1,0 +1,257 @@
+package org.openapitools.model;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト作成・更新情報
+ */
+@JsonTypeName("ProjectRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:05.399151358+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectRequest  implements Serializable {
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectRequest name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     * minimum: 1
+     */
+    public ProjectRequest sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     * minimum: 1
+     */
+    public ProjectRequest profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectRequest startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectRequest endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectRequest registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectRequest tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectRequest addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectRequest removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectRequest client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectRequest projectRequest = (ProjectRequest) o;
+        return Objects.equals(this.name, projectRequest.name) &&
+            Objects.equals(this.sales, projectRequest.sales) &&
+            Objects.equals(this.profit, projectRequest.profit) &&
+            Objects.equals(this.startDate, projectRequest.startDate) &&
+            Objects.equals(this.endDate, projectRequest.endDate) &&
+            Objects.equals(this.registeredDateTime, projectRequest.registeredDateTime) &&
+            Objects.equals(this.tags, projectRequest.tags) &&
+            Objects.equals(this.client, projectRequest.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectRequest {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/serializableModel/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/serializableModel/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
@@ -1,0 +1,278 @@
+package org.openapitools.model;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト情報
+ */
+@JsonTypeName("ProjectResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:05.399151358+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectResponse  implements Serializable {
+  private UUID id;
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクトID
+     */
+    public ProjectResponse id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectResponse name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     */
+    public ProjectResponse sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     */
+    public ProjectResponse profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectResponse startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectResponse endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectResponse registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectResponse tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectResponse addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectResponse removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectResponse client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectResponse projectResponse = (ProjectResponse) o;
+        return Objects.equals(this.id, projectResponse.id) &&
+            Objects.equals(this.name, projectResponse.name) &&
+            Objects.equals(this.sales, projectResponse.sales) &&
+            Objects.equals(this.profit, projectResponse.profit) &&
+            Objects.equals(this.startDate, projectResponse.startDate) &&
+            Objects.equals(this.endDate, projectResponse.endDate) &&
+            Objects.equals(this.registeredDateTime, projectResponse.registeredDateTime) &&
+            Objects.equals(this.tags, projectResponse.tags) &&
+            Objects.equals(this.client, projectResponse.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/serializableModel/expected/src/gen/java/org/openapitools/model/UserRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/serializableModel/expected/src/gen/java/org/openapitools/model/UserRequest.java
@@ -1,0 +1,148 @@
+package org.openapitools.model;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ登録・更新情報
+ */
+@JsonTypeName("UserRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:05.399151358+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserRequest  implements Serializable {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserRequest firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserRequest lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     * minimum: 1
+     */
+    public UserRequest age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserRequest birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserRequest userRequest = (UserRequest) o;
+        return Objects.equals(this.firstName, userRequest.firstName) &&
+            Objects.equals(this.lastName, userRequest.lastName) &&
+            Objects.equals(this.age, userRequest.age) &&
+            Objects.equals(this.birthday, userRequest.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserRequest {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/serializableModel/expected/src/gen/java/org/openapitools/model/UserResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/serializableModel/expected/src/gen/java/org/openapitools/model/UserResponse.java
@@ -1,0 +1,147 @@
+package org.openapitools.model;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ情報
+ */
+@JsonTypeName("UserResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:05.399151358+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserResponse  implements Serializable {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserResponse firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserResponse lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     */
+    public UserResponse age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserResponse birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserResponse userResponse = (UserResponse) o;
+        return Objects.equals(this.firstName, userResponse.firstName) &&
+            Objects.equals(this.lastName, userResponse.lastName) &&
+            Objects.equals(this.age, userResponse.age) &&
+            Objects.equals(this.birthday, userResponse.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserResponse {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/sourceFolder/expected/src/oai-gen/main/java/org/openapitools/api/ProjectsApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/sourceFolder/expected/src/oai-gen/main/java/org/openapitools/api/ProjectsApi.java
@@ -1,0 +1,108 @@
+package org.openapitools.api;
+
+import org.openapitools.model.Client;
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.ProjectRequest;
+import org.openapitools.model.ProjectResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/projects")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.249206820+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface ProjectsApi {
+    /**
+     * POST  : プロジェクトを作成する
+     *
+     * 情報を指定してプロジェクトを作成する
+     *
+     * @param projectRequest プロジェクト登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> createProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : プロジェクトを削除する
+     *
+     * IDを指定してプロジェクトを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project deleted
+     * @return not found project
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{projectId}/clients : プロジェクト内のクライアント一覧取得
+     *
+     * プロジェクト内のクライアント一覧を取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return プロジェクト内のクライアント一覧
+     */
+    @GET
+    @Path("/{projectId}/clients")
+    @Produces({ "application/json" })
+    EntityResponse<List<Client>> findAllClientsInProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのプロジェクトを取得する
+     *
+     * すべてのプロジェクトを取得する。タグとソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all projects
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<ProjectResponse>> findAllProjects(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : プロジェクトを取得する
+     *
+     * IDを指定してプロジェクトを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find project by id
+     * @return not found project
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> findProjectById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : プロジェクトを更新する
+     *
+     * IDを指定してプロジェクトを更新する
+     *
+     * @param projectRequest プロジェクト更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project updated
+     * @return request invalid
+     * @return not found project
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    HttpResponse updateProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/sourceFolder/expected/src/oai-gen/main/java/org/openapitools/api/UsersApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/sourceFolder/expected/src/oai-gen/main/java/org/openapitools/api/UsersApi.java
@@ -1,0 +1,92 @@
+package org.openapitools.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.UserRequest;
+import org.openapitools.model.UserResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/users")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.249206820+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface UsersApi {
+    /**
+     * POST  : ユーザを作成する
+     *
+     * 情報を指定してユーザを作成する
+     *
+     * @param userRequest ユーザ登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> createUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : ユーザを削除する
+     *
+     * IDを指定してユーザを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user deleted
+     * @return not found user
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteUser(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのユーザを取得する
+     *
+     * すべてのユーザを取得する。ソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all users
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<UserResponse>> findAllUsers(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : ユーザを取得する
+     *
+     * IDを指定してユーザを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find user by id
+     * @return not found user
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> findUserById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : ユーザを更新する
+     *
+     * IDを指定してユーザを更新する
+     *
+     * @param userRequest ユーザ更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user updated
+     * @return request invalid
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    HttpResponse updateUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/sourceFolder/expected/src/oai-gen/main/java/org/openapitools/model/Client.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/sourceFolder/expected/src/oai-gen/main/java/org/openapitools/model/Client.java
@@ -1,0 +1,102 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * クライアント情報
+ */
+@JsonTypeName("Client")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.249206820+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class Client   {
+  private UUID id;
+  private String name;
+
+    /**
+     * クライアントID
+     */
+    public Client id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * クライアント名
+     */
+    public Client name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Client client = (Client) o;
+        return Objects.equals(this.id, client.id) &&
+            Objects.equals(this.name, client.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Client {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/sourceFolder/expected/src/oai-gen/main/java/org/openapitools/model/ErrorResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/sourceFolder/expected/src/oai-gen/main/java/org/openapitools/model/ErrorResponse.java
@@ -1,0 +1,79 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * エラーレスポンス
+ */
+@JsonTypeName("ErrorResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.249206820+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ErrorResponse   {
+  private String message;
+
+    /**
+     * メッセージ
+     */
+    public ErrorResponse message(String message) {
+        this.message = message;
+        return this;
+    }
+
+    
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ErrorResponse errorResponse = (ErrorResponse) o;
+        return Objects.equals(this.message, errorResponse.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(message);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ErrorResponse {\n");
+        
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/sourceFolder/expected/src/oai-gen/main/java/org/openapitools/model/ProjectRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/sourceFolder/expected/src/oai-gen/main/java/org/openapitools/model/ProjectRequest.java
@@ -1,0 +1,256 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト作成・更新情報
+ */
+@JsonTypeName("ProjectRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.249206820+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectRequest   {
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectRequest name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     * minimum: 1
+     */
+    public ProjectRequest sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     * minimum: 1
+     */
+    public ProjectRequest profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectRequest startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectRequest endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectRequest registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectRequest tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectRequest addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectRequest removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectRequest client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectRequest projectRequest = (ProjectRequest) o;
+        return Objects.equals(this.name, projectRequest.name) &&
+            Objects.equals(this.sales, projectRequest.sales) &&
+            Objects.equals(this.profit, projectRequest.profit) &&
+            Objects.equals(this.startDate, projectRequest.startDate) &&
+            Objects.equals(this.endDate, projectRequest.endDate) &&
+            Objects.equals(this.registeredDateTime, projectRequest.registeredDateTime) &&
+            Objects.equals(this.tags, projectRequest.tags) &&
+            Objects.equals(this.client, projectRequest.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectRequest {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/sourceFolder/expected/src/oai-gen/main/java/org/openapitools/model/ProjectResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/sourceFolder/expected/src/oai-gen/main/java/org/openapitools/model/ProjectResponse.java
@@ -1,0 +1,277 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト情報
+ */
+@JsonTypeName("ProjectResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.249206820+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectResponse   {
+  private UUID id;
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクトID
+     */
+    public ProjectResponse id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectResponse name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     */
+    public ProjectResponse sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     */
+    public ProjectResponse profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectResponse startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectResponse endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectResponse registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectResponse tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectResponse addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectResponse removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectResponse client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectResponse projectResponse = (ProjectResponse) o;
+        return Objects.equals(this.id, projectResponse.id) &&
+            Objects.equals(this.name, projectResponse.name) &&
+            Objects.equals(this.sales, projectResponse.sales) &&
+            Objects.equals(this.profit, projectResponse.profit) &&
+            Objects.equals(this.startDate, projectResponse.startDate) &&
+            Objects.equals(this.endDate, projectResponse.endDate) &&
+            Objects.equals(this.registeredDateTime, projectResponse.registeredDateTime) &&
+            Objects.equals(this.tags, projectResponse.tags) &&
+            Objects.equals(this.client, projectResponse.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/sourceFolder/expected/src/oai-gen/main/java/org/openapitools/model/UserRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/sourceFolder/expected/src/oai-gen/main/java/org/openapitools/model/UserRequest.java
@@ -1,0 +1,147 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ登録・更新情報
+ */
+@JsonTypeName("UserRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.249206820+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserRequest   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserRequest firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserRequest lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     * minimum: 1
+     */
+    public UserRequest age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserRequest birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserRequest userRequest = (UserRequest) o;
+        return Objects.equals(this.firstName, userRequest.firstName) &&
+            Objects.equals(this.lastName, userRequest.lastName) &&
+            Objects.equals(this.age, userRequest.age) &&
+            Objects.equals(this.birthday, userRequest.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserRequest {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/sourceFolder/expected/src/oai-gen/main/java/org/openapitools/model/UserResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/sourceFolder/expected/src/oai-gen/main/java/org/openapitools/model/UserResponse.java
@@ -1,0 +1,146 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ情報
+ */
+@JsonTypeName("UserResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.249206820+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserResponse   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserResponse firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserResponse lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     */
+    public UserResponse age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserResponse birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserResponse userResponse = (UserResponse) o;
+        return Objects.equals(this.firstName, userResponse.firstName) &&
+            Objects.equals(this.lastName, userResponse.lastName) &&
+            Objects.equals(this.age, userResponse.age) &&
+            Objects.equals(this.birthday, userResponse.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserResponse {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/supportConsumesMediaTypes/expected/src/gen/java/org/openapitools/api/ProjectsApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/supportConsumesMediaTypes/expected/src/gen/java/org/openapitools/api/ProjectsApi.java
@@ -1,0 +1,108 @@
+package org.openapitools.api;
+
+import org.openapitools.model.Client;
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.ProjectRequest;
+import org.openapitools.model.ProjectResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/projects")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:05.927914097+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface ProjectsApi {
+    /**
+     * POST  : プロジェクトを作成する
+     *
+     * 情報を指定してプロジェクトを作成する
+     *
+     * @param projectRequest プロジェクト登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json", "application/xml" })
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> createProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : プロジェクトを削除する
+     *
+     * IDを指定してプロジェクトを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project deleted
+     * @return not found project
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{projectId}/clients : プロジェクト内のクライアント一覧取得
+     *
+     * プロジェクト内のクライアント一覧を取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return プロジェクト内のクライアント一覧
+     */
+    @GET
+    @Path("/{projectId}/clients")
+    @Produces({ "application/json" })
+    EntityResponse<List<Client>> findAllClientsInProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのプロジェクトを取得する
+     *
+     * すべてのプロジェクトを取得する。タグとソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all projects
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<ProjectResponse>> findAllProjects(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : プロジェクトを取得する
+     *
+     * IDを指定してプロジェクトを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find project by id
+     * @return not found project
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> findProjectById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : プロジェクトを更新する
+     *
+     * IDを指定してプロジェクトを更新する
+     *
+     * @param projectRequest プロジェクト更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project updated
+     * @return request invalid
+     * @return not found project
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json", "application/xml" })
+    @Produces({ "application/json" })
+    HttpResponse updateProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/supportConsumesMediaTypes/expected/src/gen/java/org/openapitools/api/UsersApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/supportConsumesMediaTypes/expected/src/gen/java/org/openapitools/api/UsersApi.java
@@ -1,0 +1,92 @@
+package org.openapitools.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.UserRequest;
+import org.openapitools.model.UserResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/users")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:05.927914097+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface UsersApi {
+    /**
+     * POST  : ユーザを作成する
+     *
+     * 情報を指定してユーザを作成する
+     *
+     * @param userRequest ユーザ登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json", "application/xml" })
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> createUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : ユーザを削除する
+     *
+     * IDを指定してユーザを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user deleted
+     * @return not found user
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteUser(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのユーザを取得する
+     *
+     * すべてのユーザを取得する。ソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all users
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<UserResponse>> findAllUsers(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : ユーザを取得する
+     *
+     * IDを指定してユーザを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find user by id
+     * @return not found user
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> findUserById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : ユーザを更新する
+     *
+     * IDを指定してユーザを更新する
+     *
+     * @param userRequest ユーザ更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user updated
+     * @return request invalid
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json", "application/xml" })
+    @Produces({ "application/json" })
+    HttpResponse updateUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/supportConsumesMediaTypes/expected/src/gen/java/org/openapitools/model/Client.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/supportConsumesMediaTypes/expected/src/gen/java/org/openapitools/model/Client.java
@@ -1,0 +1,102 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * クライアント情報
+ */
+@JsonTypeName("Client")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:05.927914097+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class Client   {
+  private UUID id;
+  private String name;
+
+    /**
+     * クライアントID
+     */
+    public Client id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * クライアント名
+     */
+    public Client name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Client client = (Client) o;
+        return Objects.equals(this.id, client.id) &&
+            Objects.equals(this.name, client.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Client {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/supportConsumesMediaTypes/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/supportConsumesMediaTypes/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
@@ -1,0 +1,79 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * エラーレスポンス
+ */
+@JsonTypeName("ErrorResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:05.927914097+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ErrorResponse   {
+  private String message;
+
+    /**
+     * メッセージ
+     */
+    public ErrorResponse message(String message) {
+        this.message = message;
+        return this;
+    }
+
+    
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ErrorResponse errorResponse = (ErrorResponse) o;
+        return Objects.equals(this.message, errorResponse.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(message);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ErrorResponse {\n");
+        
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/supportConsumesMediaTypes/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/supportConsumesMediaTypes/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
@@ -1,0 +1,256 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト作成・更新情報
+ */
+@JsonTypeName("ProjectRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:05.927914097+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectRequest   {
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectRequest name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     * minimum: 1
+     */
+    public ProjectRequest sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     * minimum: 1
+     */
+    public ProjectRequest profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectRequest startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectRequest endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectRequest registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectRequest tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectRequest addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectRequest removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectRequest client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectRequest projectRequest = (ProjectRequest) o;
+        return Objects.equals(this.name, projectRequest.name) &&
+            Objects.equals(this.sales, projectRequest.sales) &&
+            Objects.equals(this.profit, projectRequest.profit) &&
+            Objects.equals(this.startDate, projectRequest.startDate) &&
+            Objects.equals(this.endDate, projectRequest.endDate) &&
+            Objects.equals(this.registeredDateTime, projectRequest.registeredDateTime) &&
+            Objects.equals(this.tags, projectRequest.tags) &&
+            Objects.equals(this.client, projectRequest.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectRequest {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/supportConsumesMediaTypes/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/supportConsumesMediaTypes/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
@@ -1,0 +1,277 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト情報
+ */
+@JsonTypeName("ProjectResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:05.927914097+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectResponse   {
+  private UUID id;
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクトID
+     */
+    public ProjectResponse id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectResponse name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     */
+    public ProjectResponse sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     */
+    public ProjectResponse profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectResponse startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectResponse endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectResponse registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectResponse tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectResponse addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectResponse removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectResponse client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectResponse projectResponse = (ProjectResponse) o;
+        return Objects.equals(this.id, projectResponse.id) &&
+            Objects.equals(this.name, projectResponse.name) &&
+            Objects.equals(this.sales, projectResponse.sales) &&
+            Objects.equals(this.profit, projectResponse.profit) &&
+            Objects.equals(this.startDate, projectResponse.startDate) &&
+            Objects.equals(this.endDate, projectResponse.endDate) &&
+            Objects.equals(this.registeredDateTime, projectResponse.registeredDateTime) &&
+            Objects.equals(this.tags, projectResponse.tags) &&
+            Objects.equals(this.client, projectResponse.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/supportConsumesMediaTypes/expected/src/gen/java/org/openapitools/model/UserRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/supportConsumesMediaTypes/expected/src/gen/java/org/openapitools/model/UserRequest.java
@@ -1,0 +1,147 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ登録・更新情報
+ */
+@JsonTypeName("UserRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:05.927914097+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserRequest   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserRequest firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserRequest lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     * minimum: 1
+     */
+    public UserRequest age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserRequest birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserRequest userRequest = (UserRequest) o;
+        return Objects.equals(this.firstName, userRequest.firstName) &&
+            Objects.equals(this.lastName, userRequest.lastName) &&
+            Objects.equals(this.age, userRequest.age) &&
+            Objects.equals(this.birthday, userRequest.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserRequest {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/supportConsumesMediaTypes/expected/src/gen/java/org/openapitools/model/UserResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/supportConsumesMediaTypes/expected/src/gen/java/org/openapitools/model/UserResponse.java
@@ -1,0 +1,146 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ情報
+ */
+@JsonTypeName("UserResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:05.927914097+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserResponse   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserResponse firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserResponse lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     */
+    public UserResponse age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserResponse birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserResponse userResponse = (UserResponse) o;
+        return Objects.equals(this.firstName, userResponse.firstName) &&
+            Objects.equals(this.lastName, userResponse.lastName) &&
+            Objects.equals(this.age, userResponse.age) &&
+            Objects.equals(this.birthday, userResponse.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserResponse {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/supportProducesMediaTypes/expected/src/gen/java/org/openapitools/api/ProjectsApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/supportProducesMediaTypes/expected/src/gen/java/org/openapitools/api/ProjectsApi.java
@@ -1,0 +1,108 @@
+package org.openapitools.api;
+
+import org.openapitools.model.Client;
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.ProjectRequest;
+import org.openapitools.model.ProjectResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/projects")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.466750443+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface ProjectsApi {
+    /**
+     * POST  : プロジェクトを作成する
+     *
+     * 情報を指定してプロジェクトを作成する
+     *
+     * @param projectRequest プロジェクト登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json", "application/xml" })
+    EntityResponse<ProjectResponse> createProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : プロジェクトを削除する
+     *
+     * IDを指定してプロジェクトを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project deleted
+     * @return not found project
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{projectId}/clients : プロジェクト内のクライアント一覧取得
+     *
+     * プロジェクト内のクライアント一覧を取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return プロジェクト内のクライアント一覧
+     */
+    @GET
+    @Path("/{projectId}/clients")
+    @Produces({ "application/json", "application/xml" })
+    EntityResponse<List<Client>> findAllClientsInProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのプロジェクトを取得する
+     *
+     * すべてのプロジェクトを取得する。タグとソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all projects
+     */
+    @GET
+    @Produces({ "application/json", "application/xml" })
+    EntityResponse<List<ProjectResponse>> findAllProjects(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : プロジェクトを取得する
+     *
+     * IDを指定してプロジェクトを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find project by id
+     * @return not found project
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json", "application/xml" })
+    EntityResponse<ProjectResponse> findProjectById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : プロジェクトを更新する
+     *
+     * IDを指定してプロジェクトを更新する
+     *
+     * @param projectRequest プロジェクト更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project updated
+     * @return request invalid
+     * @return not found project
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json", "application/xml" })
+    HttpResponse updateProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/supportProducesMediaTypes/expected/src/gen/java/org/openapitools/api/UsersApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/supportProducesMediaTypes/expected/src/gen/java/org/openapitools/api/UsersApi.java
@@ -1,0 +1,92 @@
+package org.openapitools.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.UserRequest;
+import org.openapitools.model.UserResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/users")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.466750443+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface UsersApi {
+    /**
+     * POST  : ユーザを作成する
+     *
+     * 情報を指定してユーザを作成する
+     *
+     * @param userRequest ユーザ登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json", "application/xml" })
+    EntityResponse<UserResponse> createUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : ユーザを削除する
+     *
+     * IDを指定してユーザを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user deleted
+     * @return not found user
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteUser(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのユーザを取得する
+     *
+     * すべてのユーザを取得する。ソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all users
+     */
+    @GET
+    @Produces({ "application/json", "application/xml" })
+    EntityResponse<List<UserResponse>> findAllUsers(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : ユーザを取得する
+     *
+     * IDを指定してユーザを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find user by id
+     * @return not found user
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json", "application/xml" })
+    EntityResponse<UserResponse> findUserById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : ユーザを更新する
+     *
+     * IDを指定してユーザを更新する
+     *
+     * @param userRequest ユーザ更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user updated
+     * @return request invalid
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json", "application/xml" })
+    HttpResponse updateUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/supportProducesMediaTypes/expected/src/gen/java/org/openapitools/model/Client.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/supportProducesMediaTypes/expected/src/gen/java/org/openapitools/model/Client.java
@@ -1,0 +1,102 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * クライアント情報
+ */
+@JsonTypeName("Client")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.466750443+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class Client   {
+  private UUID id;
+  private String name;
+
+    /**
+     * クライアントID
+     */
+    public Client id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * クライアント名
+     */
+    public Client name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Client client = (Client) o;
+        return Objects.equals(this.id, client.id) &&
+            Objects.equals(this.name, client.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Client {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/supportProducesMediaTypes/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/supportProducesMediaTypes/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
@@ -1,0 +1,79 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * エラーレスポンス
+ */
+@JsonTypeName("ErrorResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.466750443+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ErrorResponse   {
+  private String message;
+
+    /**
+     * メッセージ
+     */
+    public ErrorResponse message(String message) {
+        this.message = message;
+        return this;
+    }
+
+    
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ErrorResponse errorResponse = (ErrorResponse) o;
+        return Objects.equals(this.message, errorResponse.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(message);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ErrorResponse {\n");
+        
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/supportProducesMediaTypes/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/supportProducesMediaTypes/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
@@ -1,0 +1,256 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト作成・更新情報
+ */
+@JsonTypeName("ProjectRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.466750443+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectRequest   {
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectRequest name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     * minimum: 1
+     */
+    public ProjectRequest sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     * minimum: 1
+     */
+    public ProjectRequest profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectRequest startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectRequest endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectRequest registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectRequest tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectRequest addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectRequest removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectRequest client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectRequest projectRequest = (ProjectRequest) o;
+        return Objects.equals(this.name, projectRequest.name) &&
+            Objects.equals(this.sales, projectRequest.sales) &&
+            Objects.equals(this.profit, projectRequest.profit) &&
+            Objects.equals(this.startDate, projectRequest.startDate) &&
+            Objects.equals(this.endDate, projectRequest.endDate) &&
+            Objects.equals(this.registeredDateTime, projectRequest.registeredDateTime) &&
+            Objects.equals(this.tags, projectRequest.tags) &&
+            Objects.equals(this.client, projectRequest.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectRequest {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/supportProducesMediaTypes/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/supportProducesMediaTypes/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
@@ -1,0 +1,277 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト情報
+ */
+@JsonTypeName("ProjectResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.466750443+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectResponse   {
+  private UUID id;
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクトID
+     */
+    public ProjectResponse id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectResponse name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     */
+    public ProjectResponse sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     */
+    public ProjectResponse profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectResponse startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectResponse endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectResponse registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectResponse tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectResponse addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectResponse removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectResponse client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectResponse projectResponse = (ProjectResponse) o;
+        return Objects.equals(this.id, projectResponse.id) &&
+            Objects.equals(this.name, projectResponse.name) &&
+            Objects.equals(this.sales, projectResponse.sales) &&
+            Objects.equals(this.profit, projectResponse.profit) &&
+            Objects.equals(this.startDate, projectResponse.startDate) &&
+            Objects.equals(this.endDate, projectResponse.endDate) &&
+            Objects.equals(this.registeredDateTime, projectResponse.registeredDateTime) &&
+            Objects.equals(this.tags, projectResponse.tags) &&
+            Objects.equals(this.client, projectResponse.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/supportProducesMediaTypes/expected/src/gen/java/org/openapitools/model/UserRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/supportProducesMediaTypes/expected/src/gen/java/org/openapitools/model/UserRequest.java
@@ -1,0 +1,147 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ登録・更新情報
+ */
+@JsonTypeName("UserRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.466750443+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserRequest   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserRequest firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserRequest lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     * minimum: 1
+     */
+    public UserRequest age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserRequest birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserRequest userRequest = (UserRequest) o;
+        return Objects.equals(this.firstName, userRequest.firstName) &&
+            Objects.equals(this.lastName, userRequest.lastName) &&
+            Objects.equals(this.age, userRequest.age) &&
+            Objects.equals(this.birthday, userRequest.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserRequest {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/supportProducesMediaTypes/expected/src/gen/java/org/openapitools/model/UserResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/supportProducesMediaTypes/expected/src/gen/java/org/openapitools/model/UserResponse.java
@@ -1,0 +1,146 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ情報
+ */
+@JsonTypeName("UserResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.466750443+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserResponse   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserResponse firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserResponse lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     */
+    public UserResponse age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserResponse birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserResponse userResponse = (UserResponse) o;
+        return Objects.equals(this.firstName, userResponse.firstName) &&
+            Objects.equals(this.lastName, userResponse.lastName) &&
+            Objects.equals(this.age, userResponse.age) &&
+            Objects.equals(this.birthday, userResponse.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserResponse {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useBeanValidation/expected/src/gen/java/org/openapitools/api/ProjectsApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useBeanValidation/expected/src/gen/java/org/openapitools/api/ProjectsApi.java
@@ -1,0 +1,111 @@
+package org.openapitools.api;
+
+import org.openapitools.model.Client;
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.ProjectRequest;
+import org.openapitools.model.ProjectResponse;
+import jakarta.validation.Valid;
+
+import jakarta.ws.rs.*;
+
+@Path("/projects")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.954889834+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface ProjectsApi {
+    /**
+     * POST  : プロジェクトを作成する
+     *
+     * 情報を指定してプロジェクトを作成する
+     *
+     * @param projectRequest プロジェクト登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @Valid
+    EntityResponse<ProjectResponse> createProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : プロジェクトを削除する
+     *
+     * IDを指定してプロジェクトを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project deleted
+     * @return not found project
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{projectId}/clients : プロジェクト内のクライアント一覧取得
+     *
+     * プロジェクト内のクライアント一覧を取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return プロジェクト内のクライアント一覧
+     */
+    @GET
+    @Path("/{projectId}/clients")
+    @Produces({ "application/json" })
+    EntityResponse<List<Client>> findAllClientsInProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのプロジェクトを取得する
+     *
+     * すべてのプロジェクトを取得する。タグとソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all projects
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<ProjectResponse>> findAllProjects(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : プロジェクトを取得する
+     *
+     * IDを指定してプロジェクトを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find project by id
+     * @return not found project
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> findProjectById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : プロジェクトを更新する
+     *
+     * IDを指定してプロジェクトを更新する
+     *
+     * @param projectRequest プロジェクト更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project updated
+     * @return request invalid
+     * @return not found project
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @Valid
+    HttpResponse updateProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useBeanValidation/expected/src/gen/java/org/openapitools/api/UsersApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useBeanValidation/expected/src/gen/java/org/openapitools/api/UsersApi.java
@@ -1,0 +1,95 @@
+package org.openapitools.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.UserRequest;
+import org.openapitools.model.UserResponse;
+import jakarta.validation.Valid;
+
+import jakarta.ws.rs.*;
+
+@Path("/users")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.954889834+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface UsersApi {
+    /**
+     * POST  : ユーザを作成する
+     *
+     * 情報を指定してユーザを作成する
+     *
+     * @param userRequest ユーザ登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @Valid
+    EntityResponse<UserResponse> createUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : ユーザを削除する
+     *
+     * IDを指定してユーザを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user deleted
+     * @return not found user
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteUser(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET  : すべてのユーザを取得する
+     *
+     * すべてのユーザを取得する。ソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all users
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<UserResponse>> findAllUsers(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : ユーザを取得する
+     *
+     * IDを指定してユーザを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find user by id
+     * @return not found user
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> findUserById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : ユーザを更新する
+     *
+     * IDを指定してユーザを更新する
+     *
+     * @param userRequest ユーザ更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user updated
+     * @return request invalid
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @Valid
+    HttpResponse updateUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useBeanValidation/expected/src/gen/java/org/openapitools/model/Client.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useBeanValidation/expected/src/gen/java/org/openapitools/model/Client.java
@@ -1,0 +1,111 @@
+package org.openapitools.model;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import java.util.Arrays;
+import java.util.UUID;
+import nablarch.core.validation.ee.DecimalRange;
+import nablarch.core.validation.ee.Length;
+import nablarch.core.validation.ee.NumberRange;
+import nablarch.core.validation.ee.Required;
+import nablarch.core.validation.ee.Size;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * クライアント情報
+ */
+@JsonTypeName("Client")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.954889834+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class Client   {
+  private UUID id;
+  private String name;
+
+    /**
+     * クライアントID
+     */
+    public Client id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    @Pattern(regexp = "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}") 
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * クライアント名
+     */
+    public Client name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Client client = (Client) o;
+        return Objects.equals(this.id, client.id) &&
+            Objects.equals(this.name, client.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Client {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useBeanValidation/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useBeanValidation/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
@@ -1,0 +1,87 @@
+package org.openapitools.model;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import java.util.Arrays;
+import nablarch.core.validation.ee.DecimalRange;
+import nablarch.core.validation.ee.Length;
+import nablarch.core.validation.ee.NumberRange;
+import nablarch.core.validation.ee.Required;
+import nablarch.core.validation.ee.Size;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * エラーレスポンス
+ */
+@JsonTypeName("ErrorResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.954889834+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ErrorResponse   {
+  private String message;
+
+    /**
+     * メッセージ
+     */
+    public ErrorResponse message(String message) {
+        this.message = message;
+        return this;
+    }
+
+    
+    @JsonProperty("message")
+    
+    public String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ErrorResponse errorResponse = (ErrorResponse) o;
+        return Objects.equals(this.message, errorResponse.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(message);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ErrorResponse {\n");
+        
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useBeanValidation/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useBeanValidation/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
@@ -1,0 +1,271 @@
+package org.openapitools.model;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import nablarch.core.validation.ee.DecimalRange;
+import nablarch.core.validation.ee.Length;
+import nablarch.core.validation.ee.NumberRange;
+import nablarch.core.validation.ee.Required;
+import nablarch.core.validation.ee.Size;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト作成・更新情報
+ */
+@JsonTypeName("ProjectRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.954889834+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectRequest   {
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private @Valid List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectRequest name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    @Required @Length(min = 1, max = 100) 
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     * minimum: 1
+     */
+    public ProjectRequest sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    @NumberRange(min = 1) 
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     * minimum: 1
+     */
+    public ProjectRequest profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    @NumberRange(min = 1) 
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectRequest startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    @Required 
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectRequest endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectRequest registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectRequest tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    @Size(max = 5) 
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectRequest addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectRequest removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectRequest client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    @Required @Valid 
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectRequest projectRequest = (ProjectRequest) o;
+        return Objects.equals(this.name, projectRequest.name) &&
+            Objects.equals(this.sales, projectRequest.sales) &&
+            Objects.equals(this.profit, projectRequest.profit) &&
+            Objects.equals(this.startDate, projectRequest.startDate) &&
+            Objects.equals(this.endDate, projectRequest.endDate) &&
+            Objects.equals(this.registeredDateTime, projectRequest.registeredDateTime) &&
+            Objects.equals(this.tags, projectRequest.tags) &&
+            Objects.equals(this.client, projectRequest.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectRequest {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useBeanValidation/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useBeanValidation/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
@@ -1,0 +1,293 @@
+package org.openapitools.model;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import nablarch.core.validation.ee.DecimalRange;
+import nablarch.core.validation.ee.Length;
+import nablarch.core.validation.ee.NumberRange;
+import nablarch.core.validation.ee.Required;
+import nablarch.core.validation.ee.Size;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト情報
+ */
+@JsonTypeName("ProjectResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.954889834+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectResponse   {
+  private UUID id;
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private @Valid List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクトID
+     */
+    public ProjectResponse id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    @Pattern(regexp = "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}") 
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectResponse name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     */
+    public ProjectResponse sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     */
+    public ProjectResponse profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectResponse startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectResponse endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectResponse registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectResponse tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectResponse addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectResponse removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectResponse client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    @Valid 
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectResponse projectResponse = (ProjectResponse) o;
+        return Objects.equals(this.id, projectResponse.id) &&
+            Objects.equals(this.name, projectResponse.name) &&
+            Objects.equals(this.sales, projectResponse.sales) &&
+            Objects.equals(this.profit, projectResponse.profit) &&
+            Objects.equals(this.startDate, projectResponse.startDate) &&
+            Objects.equals(this.endDate, projectResponse.endDate) &&
+            Objects.equals(this.registeredDateTime, projectResponse.registeredDateTime) &&
+            Objects.equals(this.tags, projectResponse.tags) &&
+            Objects.equals(this.client, projectResponse.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useBeanValidation/expected/src/gen/java/org/openapitools/model/UserRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useBeanValidation/expected/src/gen/java/org/openapitools/model/UserRequest.java
@@ -1,0 +1,158 @@
+package org.openapitools.model;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDate;
+import java.util.Arrays;
+import nablarch.core.validation.ee.DecimalRange;
+import nablarch.core.validation.ee.Length;
+import nablarch.core.validation.ee.NumberRange;
+import nablarch.core.validation.ee.Required;
+import nablarch.core.validation.ee.Size;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ登録・更新情報
+ */
+@JsonTypeName("UserRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.954889834+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserRequest   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserRequest firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    @Required @Length(min = 1) 
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserRequest lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    @Required @Length(min = 1) 
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     * minimum: 1
+     */
+    public UserRequest age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    @NumberRange(min = 1) 
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserRequest birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserRequest userRequest = (UserRequest) o;
+        return Objects.equals(this.firstName, userRequest.firstName) &&
+            Objects.equals(this.lastName, userRequest.lastName) &&
+            Objects.equals(this.age, userRequest.age) &&
+            Objects.equals(this.birthday, userRequest.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserRequest {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useBeanValidation/expected/src/gen/java/org/openapitools/model/UserResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useBeanValidation/expected/src/gen/java/org/openapitools/model/UserResponse.java
@@ -1,0 +1,157 @@
+package org.openapitools.model;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDate;
+import java.util.Arrays;
+import nablarch.core.validation.ee.DecimalRange;
+import nablarch.core.validation.ee.Length;
+import nablarch.core.validation.ee.NumberRange;
+import nablarch.core.validation.ee.Required;
+import nablarch.core.validation.ee.Size;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ情報
+ */
+@JsonTypeName("UserResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.954889834+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserResponse   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserResponse firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserResponse lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     */
+    public UserResponse age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserResponse birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserResponse userResponse = (UserResponse) o;
+        return Objects.equals(this.firstName, userResponse.firstName) &&
+            Objects.equals(this.lastName, userResponse.lastName) &&
+            Objects.equals(this.age, userResponse.age) &&
+            Objects.equals(this.birthday, userResponse.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserResponse {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useTags/expected/src/gen/java/org/openapitools/api/ClientReadApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useTags/expected/src/gen/java/org/openapitools/api/ClientReadApi.java
@@ -1,0 +1,28 @@
+package org.openapitools.api;
+
+import org.openapitools.model.Client;
+import nablarch.fw.jaxrs.EntityResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+
+import jakarta.ws.rs.*;
+
+@Path("/projects/{projectId}/clients")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:55:14.862304511+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface ClientReadApi {
+    /**
+     * GET  : プロジェクト内のクライアント一覧取得
+     *
+     * プロジェクト内のクライアント一覧を取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return プロジェクト内のクライアント一覧
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<Client>> findAllClientsInProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useTags/expected/src/gen/java/org/openapitools/api/ProjectReadApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useTags/expected/src/gen/java/org/openapitools/api/ProjectReadApi.java
@@ -1,0 +1,43 @@
+package org.openapitools.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.ProjectResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/projects")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:55:14.862304511+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface ProjectReadApi {
+    /**
+     * GET  : すべてのプロジェクトを取得する
+     *
+     * すべてのプロジェクトを取得する。タグとソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all projects
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<ProjectResponse>> findAllProjects(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : プロジェクトを取得する
+     *
+     * IDを指定してプロジェクトを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find project by id
+     * @return not found project
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> findProjectById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useTags/expected/src/gen/java/org/openapitools/api/ProjectWriteApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useTags/expected/src/gen/java/org/openapitools/api/ProjectWriteApi.java
@@ -1,0 +1,64 @@
+package org.openapitools.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import org.openapitools.model.ProjectRequest;
+import org.openapitools.model.ProjectResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/projects")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:55:14.862304511+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface ProjectWriteApi {
+    /**
+     * POST  : プロジェクトを作成する
+     *
+     * 情報を指定してプロジェクトを作成する
+     *
+     * @param projectRequest プロジェクト登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> createProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : プロジェクトを削除する
+     *
+     * IDを指定してプロジェクトを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project deleted
+     * @return not found project
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : プロジェクトを更新する
+     *
+     * IDを指定してプロジェクトを更新する
+     *
+     * @param projectRequest プロジェクト更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project updated
+     * @return request invalid
+     * @return not found project
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    HttpResponse updateProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useTags/expected/src/gen/java/org/openapitools/api/UserReadApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useTags/expected/src/gen/java/org/openapitools/api/UserReadApi.java
@@ -1,0 +1,43 @@
+package org.openapitools.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.UserResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/users")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:55:14.862304511+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface UserReadApi {
+    /**
+     * GET  : すべてのユーザを取得する
+     *
+     * すべてのユーザを取得する。ソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all users
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<UserResponse>> findAllUsers(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{id} : ユーザを取得する
+     *
+     * IDを指定してユーザを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find user by id
+     * @return not found user
+     */
+    @GET
+    @Path("/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> findUserById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useTags/expected/src/gen/java/org/openapitools/api/UserWriteApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useTags/expected/src/gen/java/org/openapitools/api/UserWriteApi.java
@@ -1,0 +1,63 @@
+package org.openapitools.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import org.openapitools.model.UserRequest;
+import org.openapitools.model.UserResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/users")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:55:14.862304511+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface UserWriteApi {
+    /**
+     * POST  : ユーザを作成する
+     *
+     * 情報を指定してユーザを作成する
+     *
+     * @param userRequest ユーザ登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user created
+     * @return request invalid
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> createUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{id} : ユーザを削除する
+     *
+     * IDを指定してユーザを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user deleted
+     * @return not found user
+     */
+    @DELETE
+    @Path("/{id}")
+    HttpResponse deleteUser(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{id} : ユーザを更新する
+     *
+     * IDを指定してユーザを更新する
+     *
+     * @param userRequest ユーザ更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user updated
+     * @return request invalid
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    HttpResponse updateUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useTags/expected/src/gen/java/org/openapitools/model/Client.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useTags/expected/src/gen/java/org/openapitools/model/Client.java
@@ -1,0 +1,102 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * クライアント情報
+ */
+@JsonTypeName("Client")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:55:14.862304511+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class Client   {
+  private UUID id;
+  private String name;
+
+    /**
+     * クライアントID
+     */
+    public Client id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * クライアント名
+     */
+    public Client name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Client client = (Client) o;
+        return Objects.equals(this.id, client.id) &&
+            Objects.equals(this.name, client.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Client {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useTags/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useTags/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
@@ -1,0 +1,79 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * エラーレスポンス
+ */
+@JsonTypeName("ErrorResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:55:14.862304511+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ErrorResponse   {
+  private String message;
+
+    /**
+     * メッセージ
+     */
+    public ErrorResponse message(String message) {
+        this.message = message;
+        return this;
+    }
+
+    
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ErrorResponse errorResponse = (ErrorResponse) o;
+        return Objects.equals(this.message, errorResponse.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(message);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ErrorResponse {\n");
+        
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useTags/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useTags/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
@@ -1,0 +1,256 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト作成・更新情報
+ */
+@JsonTypeName("ProjectRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:55:14.862304511+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectRequest   {
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectRequest name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     * minimum: 1
+     */
+    public ProjectRequest sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     * minimum: 1
+     */
+    public ProjectRequest profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectRequest startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectRequest endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectRequest registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectRequest tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectRequest addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectRequest removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectRequest client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectRequest projectRequest = (ProjectRequest) o;
+        return Objects.equals(this.name, projectRequest.name) &&
+            Objects.equals(this.sales, projectRequest.sales) &&
+            Objects.equals(this.profit, projectRequest.profit) &&
+            Objects.equals(this.startDate, projectRequest.startDate) &&
+            Objects.equals(this.endDate, projectRequest.endDate) &&
+            Objects.equals(this.registeredDateTime, projectRequest.registeredDateTime) &&
+            Objects.equals(this.tags, projectRequest.tags) &&
+            Objects.equals(this.client, projectRequest.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectRequest {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useTags/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useTags/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
@@ -1,0 +1,277 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト情報
+ */
+@JsonTypeName("ProjectResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:55:14.862304511+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectResponse   {
+  private UUID id;
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクトID
+     */
+    public ProjectResponse id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectResponse name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     */
+    public ProjectResponse sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     */
+    public ProjectResponse profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectResponse startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectResponse endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectResponse registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectResponse tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectResponse addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectResponse removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectResponse client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectResponse projectResponse = (ProjectResponse) o;
+        return Objects.equals(this.id, projectResponse.id) &&
+            Objects.equals(this.name, projectResponse.name) &&
+            Objects.equals(this.sales, projectResponse.sales) &&
+            Objects.equals(this.profit, projectResponse.profit) &&
+            Objects.equals(this.startDate, projectResponse.startDate) &&
+            Objects.equals(this.endDate, projectResponse.endDate) &&
+            Objects.equals(this.registeredDateTime, projectResponse.registeredDateTime) &&
+            Objects.equals(this.tags, projectResponse.tags) &&
+            Objects.equals(this.client, projectResponse.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useTags/expected/src/gen/java/org/openapitools/model/UserRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useTags/expected/src/gen/java/org/openapitools/model/UserRequest.java
@@ -1,0 +1,147 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ登録・更新情報
+ */
+@JsonTypeName("UserRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:55:14.862304511+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserRequest   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserRequest firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserRequest lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     * minimum: 1
+     */
+    public UserRequest age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserRequest birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserRequest userRequest = (UserRequest) o;
+        return Objects.equals(this.firstName, userRequest.firstName) &&
+            Objects.equals(this.lastName, userRequest.lastName) &&
+            Objects.equals(this.age, userRequest.age) &&
+            Objects.equals(this.birthday, userRequest.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserRequest {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useTags/expected/src/gen/java/org/openapitools/model/UserResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useTags/expected/src/gen/java/org/openapitools/model/UserResponse.java
@@ -1,0 +1,146 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ情報
+ */
+@JsonTypeName("UserResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:55:14.862304511+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserResponse   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserResponse firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserResponse lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     */
+    public UserResponse age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserResponse birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserResponse userResponse = (UserResponse) o;
+        return Objects.equals(this.firstName, userResponse.firstName) &&
+            Objects.equals(this.lastName, userResponse.lastName) &&
+            Objects.equals(this.age, userResponse.age) &&
+            Objects.equals(this.birthday, userResponse.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserResponse {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useTagsForMultipleTag/expected/src/gen/java/org/openapitools/api/ReadApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useTagsForMultipleTag/expected/src/gen/java/org/openapitools/api/ReadApi.java
@@ -1,0 +1,89 @@
+package org.openapitools.api;
+
+import org.openapitools.model.Client;
+import nablarch.fw.jaxrs.EntityResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.ProjectResponse;
+import org.openapitools.model.UserResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.682898951+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface ReadApi {
+    /**
+     * GET /projects/{projectId}/clients : プロジェクト内のクライアント一覧取得
+     *
+     * プロジェクト内のクライアント一覧を取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return プロジェクト内のクライアント一覧
+     */
+    @GET
+    @Path("/projects/{projectId}/clients")
+    @Produces({ "application/json" })
+    EntityResponse<List<Client>> findAllClientsInProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /projects : すべてのプロジェクトを取得する
+     *
+     * すべてのプロジェクトを取得する。タグとソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all projects
+     */
+    @GET
+    @Path("/projects")
+    @Produces({ "application/json" })
+    EntityResponse<List<ProjectResponse>> findAllProjects(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /users : すべてのユーザを取得する
+     *
+     * すべてのユーザを取得する。ソート順を指定できる
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find all users
+     */
+    @GET
+    @Path("/users")
+    @Produces({ "application/json" })
+    EntityResponse<List<UserResponse>> findAllUsers(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /projects/{id} : プロジェクトを取得する
+     *
+     * IDを指定してプロジェクトを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find project by id
+     * @return not found project
+     */
+    @GET
+    @Path("/projects/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> findProjectById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /users/{id} : ユーザを取得する
+     *
+     * IDを指定してユーザを取得する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return find user by id
+     * @return not found user
+     */
+    @GET
+    @Path("/users/{id}")
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> findUserById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useTagsForMultipleTag/expected/src/gen/java/org/openapitools/api/WriteApi.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useTagsForMultipleTag/expected/src/gen/java/org/openapitools/api/WriteApi.java
@@ -1,0 +1,115 @@
+package org.openapitools.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import org.openapitools.model.ErrorResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import org.openapitools.model.ProjectRequest;
+import org.openapitools.model.ProjectResponse;
+import org.openapitools.model.UserRequest;
+import org.openapitools.model.UserResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.682898951+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface WriteApi {
+    /**
+     * POST /projects : プロジェクトを作成する
+     *
+     * 情報を指定してプロジェクトを作成する
+     *
+     * @param projectRequest プロジェクト登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project created
+     * @return request invalid
+     */
+    @POST
+    @Path("/projects")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<ProjectResponse> createProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * POST /users : ユーザを作成する
+     *
+     * 情報を指定してユーザを作成する
+     *
+     * @param userRequest ユーザ登録情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user created
+     * @return request invalid
+     */
+    @POST
+    @Path("/users")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<UserResponse> createUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /projects/{id} : プロジェクトを削除する
+     *
+     * IDを指定してプロジェクトを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project deleted
+     * @return not found project
+     */
+    @DELETE
+    @Path("/projects/{id}")
+    HttpResponse deleteProject(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /users/{id} : ユーザを削除する
+     *
+     * IDを指定してユーザを削除する
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user deleted
+     * @return not found user
+     */
+    @DELETE
+    @Path("/users/{id}")
+    HttpResponse deleteUser(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /projects/{id} : プロジェクトを更新する
+     *
+     * IDを指定してプロジェクトを更新する
+     *
+     * @param projectRequest プロジェクト更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return project updated
+     * @return request invalid
+     * @return not found project
+     */
+    @PUT
+    @Path("/projects/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    HttpResponse updateProject(ProjectRequest projectRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /users/{id} : ユーザを更新する
+     *
+     * IDを指定してユーザを更新する
+     *
+     * @param userRequest ユーザ更新情報
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return user updated
+     * @return request invalid
+     */
+    @PUT
+    @Path("/users/{id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    HttpResponse updateUser(UserRequest userRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useTagsForMultipleTag/expected/src/gen/java/org/openapitools/model/Client.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useTagsForMultipleTag/expected/src/gen/java/org/openapitools/model/Client.java
@@ -1,0 +1,102 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * クライアント情報
+ */
+@JsonTypeName("Client")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.682898951+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class Client   {
+  private UUID id;
+  private String name;
+
+    /**
+     * クライアントID
+     */
+    public Client id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * クライアント名
+     */
+    public Client name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Client client = (Client) o;
+        return Objects.equals(this.id, client.id) &&
+            Objects.equals(this.name, client.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Client {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useTagsForMultipleTag/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useTagsForMultipleTag/expected/src/gen/java/org/openapitools/model/ErrorResponse.java
@@ -1,0 +1,79 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * エラーレスポンス
+ */
+@JsonTypeName("ErrorResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.682898951+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ErrorResponse   {
+  private String message;
+
+    /**
+     * メッセージ
+     */
+    public ErrorResponse message(String message) {
+        this.message = message;
+        return this;
+    }
+
+    
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ErrorResponse errorResponse = (ErrorResponse) o;
+        return Objects.equals(this.message, errorResponse.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(message);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ErrorResponse {\n");
+        
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useTagsForMultipleTag/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useTagsForMultipleTag/expected/src/gen/java/org/openapitools/model/ProjectRequest.java
@@ -1,0 +1,256 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト作成・更新情報
+ */
+@JsonTypeName("ProjectRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.682898951+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectRequest   {
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectRequest name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     * minimum: 1
+     */
+    public ProjectRequest sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     * minimum: 1
+     */
+    public ProjectRequest profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectRequest startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectRequest endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectRequest registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectRequest tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectRequest addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectRequest removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectRequest client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectRequest projectRequest = (ProjectRequest) o;
+        return Objects.equals(this.name, projectRequest.name) &&
+            Objects.equals(this.sales, projectRequest.sales) &&
+            Objects.equals(this.profit, projectRequest.profit) &&
+            Objects.equals(this.startDate, projectRequest.startDate) &&
+            Objects.equals(this.endDate, projectRequest.endDate) &&
+            Objects.equals(this.registeredDateTime, projectRequest.registeredDateTime) &&
+            Objects.equals(this.tags, projectRequest.tags) &&
+            Objects.equals(this.client, projectRequest.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectRequest {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useTagsForMultipleTag/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useTagsForMultipleTag/expected/src/gen/java/org/openapitools/model/ProjectResponse.java
@@ -1,0 +1,277 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.openapitools.model.Client;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * プロジェクト情報
+ */
+@JsonTypeName("ProjectResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.682898951+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ProjectResponse   {
+  private UUID id;
+  private String name;
+  private Long sales;
+  private Integer profit;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private OffsetDateTime registeredDateTime;
+  private List<String> tags = new ArrayList<>();
+  private Client client;
+
+    /**
+     * プロジェクトID
+     */
+    public ProjectResponse id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public UUID getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * プロジェクト名
+     */
+    public ProjectResponse name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 売上
+     */
+    public ProjectResponse sales(Long sales) {
+        this.sales = sales;
+        return this;
+    }
+
+    
+    @JsonProperty("sales")
+    public Long getSales() {
+        return sales;
+    }
+
+    @JsonProperty("sales")
+    public void setSales(Long sales) {
+        this.sales = sales;
+    }
+
+    /**
+     * 利益
+     */
+    public ProjectResponse profit(Integer profit) {
+        this.profit = profit;
+        return this;
+    }
+
+    
+    @JsonProperty("profit")
+    public Integer getProfit() {
+        return profit;
+    }
+
+    @JsonProperty("profit")
+    public void setProfit(Integer profit) {
+        this.profit = profit;
+    }
+
+    /**
+     * 開始日
+     */
+    public ProjectResponse startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    
+    @JsonProperty("startDate")
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonProperty("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 終了日
+     */
+    public ProjectResponse endDate(LocalDate endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    
+    @JsonProperty("endDate")
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * 登録日時
+     */
+    public ProjectResponse registeredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+        return this;
+    }
+
+    
+    @JsonProperty("registeredDateTime")
+    public OffsetDateTime getRegisteredDateTime() {
+        return registeredDateTime;
+    }
+
+    @JsonProperty("registeredDateTime")
+    public void setRegisteredDateTime(OffsetDateTime registeredDateTime) {
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    /**
+     * タグ
+     */
+    public ProjectResponse tags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<String> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public ProjectResponse addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public ProjectResponse removeTagsItem(String tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * クライアント情報
+     */
+    public ProjectResponse client(Client client) {
+        this.client = client;
+        return this;
+    }
+
+    
+    @JsonProperty("client")
+    public Client getClient() {
+        return client;
+    }
+
+    @JsonProperty("client")
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProjectResponse projectResponse = (ProjectResponse) o;
+        return Objects.equals(this.id, projectResponse.id) &&
+            Objects.equals(this.name, projectResponse.name) &&
+            Objects.equals(this.sales, projectResponse.sales) &&
+            Objects.equals(this.profit, projectResponse.profit) &&
+            Objects.equals(this.startDate, projectResponse.startDate) &&
+            Objects.equals(this.endDate, projectResponse.endDate) &&
+            Objects.equals(this.registeredDateTime, projectResponse.registeredDateTime) &&
+            Objects.equals(this.tags, projectResponse.tags) &&
+            Objects.equals(this.client, projectResponse.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, sales, profit, startDate, endDate, registeredDateTime, tags, client);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProjectResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    sales: ").append(toIndentedString(sales)).append("\n");
+        sb.append("    profit: ").append(toIndentedString(profit)).append("\n");
+        sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+        sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+        sb.append("    registeredDateTime: ").append(toIndentedString(registeredDateTime)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    client: ").append(toIndentedString(client)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useTagsForMultipleTag/expected/src/gen/java/org/openapitools/model/UserRequest.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useTagsForMultipleTag/expected/src/gen/java/org/openapitools/model/UserRequest.java
@@ -1,0 +1,147 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ登録・更新情報
+ */
+@JsonTypeName("UserRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.682898951+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserRequest   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserRequest firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserRequest lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     * minimum: 1
+     */
+    public UserRequest age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserRequest birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserRequest userRequest = (UserRequest) o;
+        return Objects.equals(this.firstName, userRequest.firstName) &&
+            Objects.equals(this.lastName, userRequest.lastName) &&
+            Objects.equals(this.age, userRequest.age) &&
+            Objects.equals(this.birthday, userRequest.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserRequest {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/CodegenOptionsTest/useTagsForMultipleTag/expected/src/gen/java/org/openapitools/model/UserResponse.java
+++ b/src/test/resources/openapi-3_0/CodegenOptionsTest/useTagsForMultipleTag/expected/src/gen/java/org/openapitools/model/UserResponse.java
@@ -1,0 +1,146 @@
+package org.openapitools.model;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * ユーザ情報
+ */
+@JsonTypeName("UserResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:46:07.682898951+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class UserResponse   {
+  private String firstName;
+  private String lastName;
+  private Integer age;
+  private LocalDate birthday;
+
+    /**
+     * 名
+     */
+    public UserResponse firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * 姓
+     */
+    public UserResponse lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * 年齢
+     */
+    public UserResponse age(Integer age) {
+        this.age = age;
+        return this;
+    }
+
+    
+    @JsonProperty("age")
+    public Integer getAge() {
+        return age;
+    }
+
+    @JsonProperty("age")
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    /**
+     * 誕生日
+     */
+    public UserResponse birthday(LocalDate birthday) {
+        this.birthday = birthday;
+        return this;
+    }
+
+    
+    @JsonProperty("birthday")
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    @JsonProperty("birthday")
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserResponse userResponse = (UserResponse) o;
+        return Objects.equals(this.firstName, userResponse.firstName) &&
+            Objects.equals(this.lastName, userResponse.lastName) &&
+            Objects.equals(this.age, userResponse.age) &&
+            Objects.equals(this.birthday, userResponse.birthday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age, birthday);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserResponse {\n");
+        
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    age: ").append(toIndentedString(age)).append("\n");
+        sb.append("    birthday: ").append(toIndentedString(birthday)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypes/expected/src/gen/java/org/openapitools/api/DataTypesApi.java
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypes/expected/src/gen/java/org/openapitools/api/DataTypesApi.java
@@ -1,0 +1,42 @@
+package org.openapitools.api;
+
+import org.openapitools.model.DataTypeRequest;
+import org.openapitools.model.DataTypeResponse;
+import nablarch.fw.jaxrs.EntityResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+
+import jakarta.ws.rs.*;
+
+@Path("/data-types")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:43:49.287174813+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface DataTypesApi {
+    /**
+     * GET 
+     *
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return OK
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<DataTypeResponse>> dataTypesGet(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * POST 
+     *
+     *
+     * @param dataTypeRequest 
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return OK
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<DataTypeResponse> dataTypesPost(DataTypeRequest dataTypeRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypes/expected/src/gen/java/org/openapitools/model/DataSubTypeRequest.java
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypes/expected/src/gen/java/org/openapitools/model/DataSubTypeRequest.java
@@ -1,0 +1,97 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+
+@JsonTypeName("DataSubTypeRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:43:49.287174813+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class DataSubTypeRequest   {
+  private String id;
+  private String name;
+
+    /**
+     */
+    public DataSubTypeRequest id(String id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     */
+    public DataSubTypeRequest name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DataSubTypeRequest dataSubTypeRequest = (DataSubTypeRequest) o;
+        return Objects.equals(this.id, dataSubTypeRequest.id) &&
+            Objects.equals(this.name, dataSubTypeRequest.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class DataSubTypeRequest {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypes/expected/src/gen/java/org/openapitools/model/DataSubTypeResponse.java
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypes/expected/src/gen/java/org/openapitools/model/DataSubTypeResponse.java
@@ -1,0 +1,97 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+
+@JsonTypeName("DataSubTypeResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:43:49.287174813+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class DataSubTypeResponse   {
+  private String id;
+  private String name;
+
+    /**
+     */
+    public DataSubTypeResponse id(String id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     */
+    public DataSubTypeResponse name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DataSubTypeResponse dataSubTypeResponse = (DataSubTypeResponse) o;
+        return Objects.equals(this.id, dataSubTypeResponse.id) &&
+            Objects.equals(this.name, dataSubTypeResponse.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class DataSubTypeResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypes/expected/src/gen/java/org/openapitools/model/DataTypeRequest.java
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypes/expected/src/gen/java/org/openapitools/model/DataTypeRequest.java
@@ -1,0 +1,493 @@
+package org.openapitools.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.openapitools.model.DataSubTypeRequest;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+
+@JsonTypeName("DataTypeRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:43:49.287174813+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class DataTypeRequest   {
+  private Integer integerProperty;
+  private Integer integerInt32Property;
+  private Long integerInt64Property;
+  private BigDecimal numberProperty;
+  private Float numberFloatProperty;
+  private Double numberDoubleProperty;
+  private Boolean booleanProperty;
+  private String stringProperty;
+  private byte[] stringByteArrayProperty;
+  private LocalDate stringDateProperty;
+  private OffsetDateTime stringDateTimeProperty;
+  private BigDecimal stringNumberProperty;
+  private UUID stringUuidProperty;
+  private URI stringUriProperty;
+  private List<String> arrayProperty = new ArrayList<>();
+  private Set<String> arrayUniqueItemsConstraintProperty = new LinkedHashSet<>();
+  private DataSubTypeRequest objectProperty;
+  private List<DataSubTypeRequest> arrayObjectProperty = new ArrayList<>();
+
+    /**
+     */
+    public DataTypeRequest integerProperty(Integer integerProperty) {
+        this.integerProperty = integerProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerProperty")
+    public Integer getIntegerProperty() {
+        return integerProperty;
+    }
+
+    @JsonProperty("integerProperty")
+    public void setIntegerProperty(Integer integerProperty) {
+        this.integerProperty = integerProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest integerInt32Property(Integer integerInt32Property) {
+        this.integerInt32Property = integerInt32Property;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt32Property")
+    public Integer getIntegerInt32Property() {
+        return integerInt32Property;
+    }
+
+    @JsonProperty("integerInt32Property")
+    public void setIntegerInt32Property(Integer integerInt32Property) {
+        this.integerInt32Property = integerInt32Property;
+    }
+
+    /**
+     */
+    public DataTypeRequest integerInt64Property(Long integerInt64Property) {
+        this.integerInt64Property = integerInt64Property;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt64Property")
+    public Long getIntegerInt64Property() {
+        return integerInt64Property;
+    }
+
+    @JsonProperty("integerInt64Property")
+    public void setIntegerInt64Property(Long integerInt64Property) {
+        this.integerInt64Property = integerInt64Property;
+    }
+
+    /**
+     */
+    public DataTypeRequest numberProperty(BigDecimal numberProperty) {
+        this.numberProperty = numberProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberProperty")
+    public BigDecimal getNumberProperty() {
+        return numberProperty;
+    }
+
+    @JsonProperty("numberProperty")
+    public void setNumberProperty(BigDecimal numberProperty) {
+        this.numberProperty = numberProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest numberFloatProperty(Float numberFloatProperty) {
+        this.numberFloatProperty = numberFloatProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberFloatProperty")
+    public Float getNumberFloatProperty() {
+        return numberFloatProperty;
+    }
+
+    @JsonProperty("numberFloatProperty")
+    public void setNumberFloatProperty(Float numberFloatProperty) {
+        this.numberFloatProperty = numberFloatProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest numberDoubleProperty(Double numberDoubleProperty) {
+        this.numberDoubleProperty = numberDoubleProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberDoubleProperty")
+    public Double getNumberDoubleProperty() {
+        return numberDoubleProperty;
+    }
+
+    @JsonProperty("numberDoubleProperty")
+    public void setNumberDoubleProperty(Double numberDoubleProperty) {
+        this.numberDoubleProperty = numberDoubleProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest booleanProperty(Boolean booleanProperty) {
+        this.booleanProperty = booleanProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("booleanProperty")
+    public Boolean getBooleanProperty() {
+        return booleanProperty;
+    }
+
+    @JsonProperty("booleanProperty")
+    public void setBooleanProperty(Boolean booleanProperty) {
+        this.booleanProperty = booleanProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringProperty(String stringProperty) {
+        this.stringProperty = stringProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringProperty")
+    public String getStringProperty() {
+        return stringProperty;
+    }
+
+    @JsonProperty("stringProperty")
+    public void setStringProperty(String stringProperty) {
+        this.stringProperty = stringProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringByteArrayProperty(byte[] stringByteArrayProperty) {
+        this.stringByteArrayProperty = stringByteArrayProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringByteArrayProperty")
+    public byte[] getStringByteArrayProperty() {
+        return stringByteArrayProperty;
+    }
+
+    @JsonProperty("stringByteArrayProperty")
+    public void setStringByteArrayProperty(byte[] stringByteArrayProperty) {
+        this.stringByteArrayProperty = stringByteArrayProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringDateProperty(LocalDate stringDateProperty) {
+        this.stringDateProperty = stringDateProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringDateProperty")
+    public LocalDate getStringDateProperty() {
+        return stringDateProperty;
+    }
+
+    @JsonProperty("stringDateProperty")
+    public void setStringDateProperty(LocalDate stringDateProperty) {
+        this.stringDateProperty = stringDateProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringDateTimeProperty(OffsetDateTime stringDateTimeProperty) {
+        this.stringDateTimeProperty = stringDateTimeProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringDateTimeProperty")
+    public OffsetDateTime getStringDateTimeProperty() {
+        return stringDateTimeProperty;
+    }
+
+    @JsonProperty("stringDateTimeProperty")
+    public void setStringDateTimeProperty(OffsetDateTime stringDateTimeProperty) {
+        this.stringDateTimeProperty = stringDateTimeProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringNumberProperty(BigDecimal stringNumberProperty) {
+        this.stringNumberProperty = stringNumberProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringNumberProperty")
+    public BigDecimal getStringNumberProperty() {
+        return stringNumberProperty;
+    }
+
+    @JsonProperty("stringNumberProperty")
+    public void setStringNumberProperty(BigDecimal stringNumberProperty) {
+        this.stringNumberProperty = stringNumberProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringUuidProperty(UUID stringUuidProperty) {
+        this.stringUuidProperty = stringUuidProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringUuidProperty")
+    public UUID getStringUuidProperty() {
+        return stringUuidProperty;
+    }
+
+    @JsonProperty("stringUuidProperty")
+    public void setStringUuidProperty(UUID stringUuidProperty) {
+        this.stringUuidProperty = stringUuidProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringUriProperty(URI stringUriProperty) {
+        this.stringUriProperty = stringUriProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringUriProperty")
+    public URI getStringUriProperty() {
+        return stringUriProperty;
+    }
+
+    @JsonProperty("stringUriProperty")
+    public void setStringUriProperty(URI stringUriProperty) {
+        this.stringUriProperty = stringUriProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest arrayProperty(List<String> arrayProperty) {
+        this.arrayProperty = arrayProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayProperty")
+    public List<String> getArrayProperty() {
+        return arrayProperty;
+    }
+
+    @JsonProperty("arrayProperty")
+    public void setArrayProperty(List<String> arrayProperty) {
+        this.arrayProperty = arrayProperty;
+    }
+
+    public DataTypeRequest addArrayPropertyItem(String arrayPropertyItem) {
+        if (this.arrayProperty == null) {
+            this.arrayProperty = new ArrayList<>();
+        }
+
+        this.arrayProperty.add(arrayPropertyItem);
+        return this;
+    }
+
+    public DataTypeRequest removeArrayPropertyItem(String arrayPropertyItem) {
+        if (arrayPropertyItem != null && this.arrayProperty != null) {
+            this.arrayProperty.remove(arrayPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public DataTypeRequest arrayUniqueItemsConstraintProperty(Set<String> arrayUniqueItemsConstraintProperty) {
+        this.arrayUniqueItemsConstraintProperty = arrayUniqueItemsConstraintProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayUniqueItemsConstraintProperty")
+    public Set<String> getArrayUniqueItemsConstraintProperty() {
+        return arrayUniqueItemsConstraintProperty;
+    }
+
+    @JsonProperty("arrayUniqueItemsConstraintProperty")
+    @JsonDeserialize(as = LinkedHashSet.class)
+    public void setArrayUniqueItemsConstraintProperty(Set<String> arrayUniqueItemsConstraintProperty) {
+        this.arrayUniqueItemsConstraintProperty = arrayUniqueItemsConstraintProperty;
+    }
+
+    public DataTypeRequest addArrayUniqueItemsConstraintPropertyItem(String arrayUniqueItemsConstraintPropertyItem) {
+        if (this.arrayUniqueItemsConstraintProperty == null) {
+            this.arrayUniqueItemsConstraintProperty = new LinkedHashSet<>();
+        }
+
+        this.arrayUniqueItemsConstraintProperty.add(arrayUniqueItemsConstraintPropertyItem);
+        return this;
+    }
+
+    public DataTypeRequest removeArrayUniqueItemsConstraintPropertyItem(String arrayUniqueItemsConstraintPropertyItem) {
+        if (arrayUniqueItemsConstraintPropertyItem != null && this.arrayUniqueItemsConstraintProperty != null) {
+            this.arrayUniqueItemsConstraintProperty.remove(arrayUniqueItemsConstraintPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public DataTypeRequest objectProperty(DataSubTypeRequest objectProperty) {
+        this.objectProperty = objectProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("objectProperty")
+    public DataSubTypeRequest getObjectProperty() {
+        return objectProperty;
+    }
+
+    @JsonProperty("objectProperty")
+    public void setObjectProperty(DataSubTypeRequest objectProperty) {
+        this.objectProperty = objectProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest arrayObjectProperty(List<DataSubTypeRequest> arrayObjectProperty) {
+        this.arrayObjectProperty = arrayObjectProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayObjectProperty")
+    public List<DataSubTypeRequest> getArrayObjectProperty() {
+        return arrayObjectProperty;
+    }
+
+    @JsonProperty("arrayObjectProperty")
+    public void setArrayObjectProperty(List<DataSubTypeRequest> arrayObjectProperty) {
+        this.arrayObjectProperty = arrayObjectProperty;
+    }
+
+    public DataTypeRequest addArrayObjectPropertyItem(DataSubTypeRequest arrayObjectPropertyItem) {
+        if (this.arrayObjectProperty == null) {
+            this.arrayObjectProperty = new ArrayList<>();
+        }
+
+        this.arrayObjectProperty.add(arrayObjectPropertyItem);
+        return this;
+    }
+
+    public DataTypeRequest removeArrayObjectPropertyItem(DataSubTypeRequest arrayObjectPropertyItem) {
+        if (arrayObjectPropertyItem != null && this.arrayObjectProperty != null) {
+            this.arrayObjectProperty.remove(arrayObjectPropertyItem);
+        }
+
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DataTypeRequest dataTypeRequest = (DataTypeRequest) o;
+        return Objects.equals(this.integerProperty, dataTypeRequest.integerProperty) &&
+            Objects.equals(this.integerInt32Property, dataTypeRequest.integerInt32Property) &&
+            Objects.equals(this.integerInt64Property, dataTypeRequest.integerInt64Property) &&
+            Objects.equals(this.numberProperty, dataTypeRequest.numberProperty) &&
+            Objects.equals(this.numberFloatProperty, dataTypeRequest.numberFloatProperty) &&
+            Objects.equals(this.numberDoubleProperty, dataTypeRequest.numberDoubleProperty) &&
+            Objects.equals(this.booleanProperty, dataTypeRequest.booleanProperty) &&
+            Objects.equals(this.stringProperty, dataTypeRequest.stringProperty) &&
+            Arrays.equals(this.stringByteArrayProperty, dataTypeRequest.stringByteArrayProperty) &&
+            Objects.equals(this.stringDateProperty, dataTypeRequest.stringDateProperty) &&
+            Objects.equals(this.stringDateTimeProperty, dataTypeRequest.stringDateTimeProperty) &&
+            Objects.equals(this.stringNumberProperty, dataTypeRequest.stringNumberProperty) &&
+            Objects.equals(this.stringUuidProperty, dataTypeRequest.stringUuidProperty) &&
+            Objects.equals(this.stringUriProperty, dataTypeRequest.stringUriProperty) &&
+            Objects.equals(this.arrayProperty, dataTypeRequest.arrayProperty) &&
+            Objects.equals(this.arrayUniqueItemsConstraintProperty, dataTypeRequest.arrayUniqueItemsConstraintProperty) &&
+            Objects.equals(this.objectProperty, dataTypeRequest.objectProperty) &&
+            Objects.equals(this.arrayObjectProperty, dataTypeRequest.arrayObjectProperty);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(integerProperty, integerInt32Property, integerInt64Property, numberProperty, numberFloatProperty, numberDoubleProperty, booleanProperty, stringProperty, Arrays.hashCode(stringByteArrayProperty), stringDateProperty, stringDateTimeProperty, stringNumberProperty, stringUuidProperty, stringUriProperty, arrayProperty, arrayUniqueItemsConstraintProperty, objectProperty, arrayObjectProperty);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class DataTypeRequest {\n");
+        
+        sb.append("    integerProperty: ").append(toIndentedString(integerProperty)).append("\n");
+        sb.append("    integerInt32Property: ").append(toIndentedString(integerInt32Property)).append("\n");
+        sb.append("    integerInt64Property: ").append(toIndentedString(integerInt64Property)).append("\n");
+        sb.append("    numberProperty: ").append(toIndentedString(numberProperty)).append("\n");
+        sb.append("    numberFloatProperty: ").append(toIndentedString(numberFloatProperty)).append("\n");
+        sb.append("    numberDoubleProperty: ").append(toIndentedString(numberDoubleProperty)).append("\n");
+        sb.append("    booleanProperty: ").append(toIndentedString(booleanProperty)).append("\n");
+        sb.append("    stringProperty: ").append(toIndentedString(stringProperty)).append("\n");
+        sb.append("    stringByteArrayProperty: ").append(toIndentedString(stringByteArrayProperty)).append("\n");
+        sb.append("    stringDateProperty: ").append(toIndentedString(stringDateProperty)).append("\n");
+        sb.append("    stringDateTimeProperty: ").append(toIndentedString(stringDateTimeProperty)).append("\n");
+        sb.append("    stringNumberProperty: ").append(toIndentedString(stringNumberProperty)).append("\n");
+        sb.append("    stringUuidProperty: ").append(toIndentedString(stringUuidProperty)).append("\n");
+        sb.append("    stringUriProperty: ").append(toIndentedString(stringUriProperty)).append("\n");
+        sb.append("    arrayProperty: ").append(toIndentedString(arrayProperty)).append("\n");
+        sb.append("    arrayUniqueItemsConstraintProperty: ").append(toIndentedString(arrayUniqueItemsConstraintProperty)).append("\n");
+        sb.append("    objectProperty: ").append(toIndentedString(objectProperty)).append("\n");
+        sb.append("    arrayObjectProperty: ").append(toIndentedString(arrayObjectProperty)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypes/expected/src/gen/java/org/openapitools/model/DataTypeResponse.java
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypes/expected/src/gen/java/org/openapitools/model/DataTypeResponse.java
@@ -1,0 +1,493 @@
+package org.openapitools.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.openapitools.model.DataSubTypeResponse;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+
+@JsonTypeName("DataTypeResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:43:49.287174813+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class DataTypeResponse   {
+  private Integer integerProperty;
+  private Integer integerInt32Property;
+  private Long integerInt64Property;
+  private BigDecimal numberProperty;
+  private Float numberFloatProperty;
+  private Double numberDoubleProperty;
+  private Boolean booleanProperty;
+  private String stringProperty;
+  private byte[] stringByteArrayProperty;
+  private LocalDate stringDateProperty;
+  private OffsetDateTime stringDateTimeProperty;
+  private BigDecimal stringNumberProperty;
+  private UUID stringUuidProperty;
+  private URI stringUriProperty;
+  private List<String> arrayProperty = new ArrayList<>();
+  private Set<String> arrayUniqueItemsConstraintProperty = new LinkedHashSet<>();
+  private DataSubTypeResponse objectProperty;
+  private List<DataSubTypeResponse> arrayObjectProperty = new ArrayList<>();
+
+    /**
+     */
+    public DataTypeResponse integerProperty(Integer integerProperty) {
+        this.integerProperty = integerProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerProperty")
+    public Integer getIntegerProperty() {
+        return integerProperty;
+    }
+
+    @JsonProperty("integerProperty")
+    public void setIntegerProperty(Integer integerProperty) {
+        this.integerProperty = integerProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse integerInt32Property(Integer integerInt32Property) {
+        this.integerInt32Property = integerInt32Property;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt32Property")
+    public Integer getIntegerInt32Property() {
+        return integerInt32Property;
+    }
+
+    @JsonProperty("integerInt32Property")
+    public void setIntegerInt32Property(Integer integerInt32Property) {
+        this.integerInt32Property = integerInt32Property;
+    }
+
+    /**
+     */
+    public DataTypeResponse integerInt64Property(Long integerInt64Property) {
+        this.integerInt64Property = integerInt64Property;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt64Property")
+    public Long getIntegerInt64Property() {
+        return integerInt64Property;
+    }
+
+    @JsonProperty("integerInt64Property")
+    public void setIntegerInt64Property(Long integerInt64Property) {
+        this.integerInt64Property = integerInt64Property;
+    }
+
+    /**
+     */
+    public DataTypeResponse numberProperty(BigDecimal numberProperty) {
+        this.numberProperty = numberProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberProperty")
+    public BigDecimal getNumberProperty() {
+        return numberProperty;
+    }
+
+    @JsonProperty("numberProperty")
+    public void setNumberProperty(BigDecimal numberProperty) {
+        this.numberProperty = numberProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse numberFloatProperty(Float numberFloatProperty) {
+        this.numberFloatProperty = numberFloatProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberFloatProperty")
+    public Float getNumberFloatProperty() {
+        return numberFloatProperty;
+    }
+
+    @JsonProperty("numberFloatProperty")
+    public void setNumberFloatProperty(Float numberFloatProperty) {
+        this.numberFloatProperty = numberFloatProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse numberDoubleProperty(Double numberDoubleProperty) {
+        this.numberDoubleProperty = numberDoubleProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberDoubleProperty")
+    public Double getNumberDoubleProperty() {
+        return numberDoubleProperty;
+    }
+
+    @JsonProperty("numberDoubleProperty")
+    public void setNumberDoubleProperty(Double numberDoubleProperty) {
+        this.numberDoubleProperty = numberDoubleProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse booleanProperty(Boolean booleanProperty) {
+        this.booleanProperty = booleanProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("booleanProperty")
+    public Boolean getBooleanProperty() {
+        return booleanProperty;
+    }
+
+    @JsonProperty("booleanProperty")
+    public void setBooleanProperty(Boolean booleanProperty) {
+        this.booleanProperty = booleanProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringProperty(String stringProperty) {
+        this.stringProperty = stringProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringProperty")
+    public String getStringProperty() {
+        return stringProperty;
+    }
+
+    @JsonProperty("stringProperty")
+    public void setStringProperty(String stringProperty) {
+        this.stringProperty = stringProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringByteArrayProperty(byte[] stringByteArrayProperty) {
+        this.stringByteArrayProperty = stringByteArrayProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringByteArrayProperty")
+    public byte[] getStringByteArrayProperty() {
+        return stringByteArrayProperty;
+    }
+
+    @JsonProperty("stringByteArrayProperty")
+    public void setStringByteArrayProperty(byte[] stringByteArrayProperty) {
+        this.stringByteArrayProperty = stringByteArrayProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringDateProperty(LocalDate stringDateProperty) {
+        this.stringDateProperty = stringDateProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringDateProperty")
+    public LocalDate getStringDateProperty() {
+        return stringDateProperty;
+    }
+
+    @JsonProperty("stringDateProperty")
+    public void setStringDateProperty(LocalDate stringDateProperty) {
+        this.stringDateProperty = stringDateProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringDateTimeProperty(OffsetDateTime stringDateTimeProperty) {
+        this.stringDateTimeProperty = stringDateTimeProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringDateTimeProperty")
+    public OffsetDateTime getStringDateTimeProperty() {
+        return stringDateTimeProperty;
+    }
+
+    @JsonProperty("stringDateTimeProperty")
+    public void setStringDateTimeProperty(OffsetDateTime stringDateTimeProperty) {
+        this.stringDateTimeProperty = stringDateTimeProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringNumberProperty(BigDecimal stringNumberProperty) {
+        this.stringNumberProperty = stringNumberProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringNumberProperty")
+    public BigDecimal getStringNumberProperty() {
+        return stringNumberProperty;
+    }
+
+    @JsonProperty("stringNumberProperty")
+    public void setStringNumberProperty(BigDecimal stringNumberProperty) {
+        this.stringNumberProperty = stringNumberProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringUuidProperty(UUID stringUuidProperty) {
+        this.stringUuidProperty = stringUuidProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringUuidProperty")
+    public UUID getStringUuidProperty() {
+        return stringUuidProperty;
+    }
+
+    @JsonProperty("stringUuidProperty")
+    public void setStringUuidProperty(UUID stringUuidProperty) {
+        this.stringUuidProperty = stringUuidProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringUriProperty(URI stringUriProperty) {
+        this.stringUriProperty = stringUriProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringUriProperty")
+    public URI getStringUriProperty() {
+        return stringUriProperty;
+    }
+
+    @JsonProperty("stringUriProperty")
+    public void setStringUriProperty(URI stringUriProperty) {
+        this.stringUriProperty = stringUriProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse arrayProperty(List<String> arrayProperty) {
+        this.arrayProperty = arrayProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayProperty")
+    public List<String> getArrayProperty() {
+        return arrayProperty;
+    }
+
+    @JsonProperty("arrayProperty")
+    public void setArrayProperty(List<String> arrayProperty) {
+        this.arrayProperty = arrayProperty;
+    }
+
+    public DataTypeResponse addArrayPropertyItem(String arrayPropertyItem) {
+        if (this.arrayProperty == null) {
+            this.arrayProperty = new ArrayList<>();
+        }
+
+        this.arrayProperty.add(arrayPropertyItem);
+        return this;
+    }
+
+    public DataTypeResponse removeArrayPropertyItem(String arrayPropertyItem) {
+        if (arrayPropertyItem != null && this.arrayProperty != null) {
+            this.arrayProperty.remove(arrayPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public DataTypeResponse arrayUniqueItemsConstraintProperty(Set<String> arrayUniqueItemsConstraintProperty) {
+        this.arrayUniqueItemsConstraintProperty = arrayUniqueItemsConstraintProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayUniqueItemsConstraintProperty")
+    public Set<String> getArrayUniqueItemsConstraintProperty() {
+        return arrayUniqueItemsConstraintProperty;
+    }
+
+    @JsonProperty("arrayUniqueItemsConstraintProperty")
+    @JsonDeserialize(as = LinkedHashSet.class)
+    public void setArrayUniqueItemsConstraintProperty(Set<String> arrayUniqueItemsConstraintProperty) {
+        this.arrayUniqueItemsConstraintProperty = arrayUniqueItemsConstraintProperty;
+    }
+
+    public DataTypeResponse addArrayUniqueItemsConstraintPropertyItem(String arrayUniqueItemsConstraintPropertyItem) {
+        if (this.arrayUniqueItemsConstraintProperty == null) {
+            this.arrayUniqueItemsConstraintProperty = new LinkedHashSet<>();
+        }
+
+        this.arrayUniqueItemsConstraintProperty.add(arrayUniqueItemsConstraintPropertyItem);
+        return this;
+    }
+
+    public DataTypeResponse removeArrayUniqueItemsConstraintPropertyItem(String arrayUniqueItemsConstraintPropertyItem) {
+        if (arrayUniqueItemsConstraintPropertyItem != null && this.arrayUniqueItemsConstraintProperty != null) {
+            this.arrayUniqueItemsConstraintProperty.remove(arrayUniqueItemsConstraintPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public DataTypeResponse objectProperty(DataSubTypeResponse objectProperty) {
+        this.objectProperty = objectProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("objectProperty")
+    public DataSubTypeResponse getObjectProperty() {
+        return objectProperty;
+    }
+
+    @JsonProperty("objectProperty")
+    public void setObjectProperty(DataSubTypeResponse objectProperty) {
+        this.objectProperty = objectProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse arrayObjectProperty(List<DataSubTypeResponse> arrayObjectProperty) {
+        this.arrayObjectProperty = arrayObjectProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayObjectProperty")
+    public List<DataSubTypeResponse> getArrayObjectProperty() {
+        return arrayObjectProperty;
+    }
+
+    @JsonProperty("arrayObjectProperty")
+    public void setArrayObjectProperty(List<DataSubTypeResponse> arrayObjectProperty) {
+        this.arrayObjectProperty = arrayObjectProperty;
+    }
+
+    public DataTypeResponse addArrayObjectPropertyItem(DataSubTypeResponse arrayObjectPropertyItem) {
+        if (this.arrayObjectProperty == null) {
+            this.arrayObjectProperty = new ArrayList<>();
+        }
+
+        this.arrayObjectProperty.add(arrayObjectPropertyItem);
+        return this;
+    }
+
+    public DataTypeResponse removeArrayObjectPropertyItem(DataSubTypeResponse arrayObjectPropertyItem) {
+        if (arrayObjectPropertyItem != null && this.arrayObjectProperty != null) {
+            this.arrayObjectProperty.remove(arrayObjectPropertyItem);
+        }
+
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DataTypeResponse dataTypeResponse = (DataTypeResponse) o;
+        return Objects.equals(this.integerProperty, dataTypeResponse.integerProperty) &&
+            Objects.equals(this.integerInt32Property, dataTypeResponse.integerInt32Property) &&
+            Objects.equals(this.integerInt64Property, dataTypeResponse.integerInt64Property) &&
+            Objects.equals(this.numberProperty, dataTypeResponse.numberProperty) &&
+            Objects.equals(this.numberFloatProperty, dataTypeResponse.numberFloatProperty) &&
+            Objects.equals(this.numberDoubleProperty, dataTypeResponse.numberDoubleProperty) &&
+            Objects.equals(this.booleanProperty, dataTypeResponse.booleanProperty) &&
+            Objects.equals(this.stringProperty, dataTypeResponse.stringProperty) &&
+            Arrays.equals(this.stringByteArrayProperty, dataTypeResponse.stringByteArrayProperty) &&
+            Objects.equals(this.stringDateProperty, dataTypeResponse.stringDateProperty) &&
+            Objects.equals(this.stringDateTimeProperty, dataTypeResponse.stringDateTimeProperty) &&
+            Objects.equals(this.stringNumberProperty, dataTypeResponse.stringNumberProperty) &&
+            Objects.equals(this.stringUuidProperty, dataTypeResponse.stringUuidProperty) &&
+            Objects.equals(this.stringUriProperty, dataTypeResponse.stringUriProperty) &&
+            Objects.equals(this.arrayProperty, dataTypeResponse.arrayProperty) &&
+            Objects.equals(this.arrayUniqueItemsConstraintProperty, dataTypeResponse.arrayUniqueItemsConstraintProperty) &&
+            Objects.equals(this.objectProperty, dataTypeResponse.objectProperty) &&
+            Objects.equals(this.arrayObjectProperty, dataTypeResponse.arrayObjectProperty);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(integerProperty, integerInt32Property, integerInt64Property, numberProperty, numberFloatProperty, numberDoubleProperty, booleanProperty, stringProperty, Arrays.hashCode(stringByteArrayProperty), stringDateProperty, stringDateTimeProperty, stringNumberProperty, stringUuidProperty, stringUriProperty, arrayProperty, arrayUniqueItemsConstraintProperty, objectProperty, arrayObjectProperty);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class DataTypeResponse {\n");
+        
+        sb.append("    integerProperty: ").append(toIndentedString(integerProperty)).append("\n");
+        sb.append("    integerInt32Property: ").append(toIndentedString(integerInt32Property)).append("\n");
+        sb.append("    integerInt64Property: ").append(toIndentedString(integerInt64Property)).append("\n");
+        sb.append("    numberProperty: ").append(toIndentedString(numberProperty)).append("\n");
+        sb.append("    numberFloatProperty: ").append(toIndentedString(numberFloatProperty)).append("\n");
+        sb.append("    numberDoubleProperty: ").append(toIndentedString(numberDoubleProperty)).append("\n");
+        sb.append("    booleanProperty: ").append(toIndentedString(booleanProperty)).append("\n");
+        sb.append("    stringProperty: ").append(toIndentedString(stringProperty)).append("\n");
+        sb.append("    stringByteArrayProperty: ").append(toIndentedString(stringByteArrayProperty)).append("\n");
+        sb.append("    stringDateProperty: ").append(toIndentedString(stringDateProperty)).append("\n");
+        sb.append("    stringDateTimeProperty: ").append(toIndentedString(stringDateTimeProperty)).append("\n");
+        sb.append("    stringNumberProperty: ").append(toIndentedString(stringNumberProperty)).append("\n");
+        sb.append("    stringUuidProperty: ").append(toIndentedString(stringUuidProperty)).append("\n");
+        sb.append("    stringUriProperty: ").append(toIndentedString(stringUriProperty)).append("\n");
+        sb.append("    arrayProperty: ").append(toIndentedString(arrayProperty)).append("\n");
+        sb.append("    arrayUniqueItemsConstraintProperty: ").append(toIndentedString(arrayUniqueItemsConstraintProperty)).append("\n");
+        sb.append("    objectProperty: ").append(toIndentedString(objectProperty)).append("\n");
+        sb.append("    arrayObjectProperty: ").append(toIndentedString(arrayObjectProperty)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypesIncludedUnofficialSupportedTypes/expected/src/gen/java/org/openapitools/api/DataTypesApi.java
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypesIncludedUnofficialSupportedTypes/expected/src/gen/java/org/openapitools/api/DataTypesApi.java
@@ -1,0 +1,42 @@
+package org.openapitools.api;
+
+import org.openapitools.model.DataTypeRequest;
+import org.openapitools.model.DataTypeResponse;
+import nablarch.fw.jaxrs.EntityResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+
+import jakarta.ws.rs.*;
+
+@Path("/data-types")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:43:48.220276849+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface DataTypesApi {
+    /**
+     * GET 
+     *
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return OK
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<DataTypeResponse>> dataTypesGet(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * POST 
+     *
+     *
+     * @param dataTypeRequest 
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return OK
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<DataTypeResponse> dataTypesPost(DataTypeRequest dataTypeRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypesIncludedUnofficialSupportedTypes/expected/src/gen/java/org/openapitools/model/DataSubTypeRequest.java
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypesIncludedUnofficialSupportedTypes/expected/src/gen/java/org/openapitools/model/DataSubTypeRequest.java
@@ -1,0 +1,97 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+
+@JsonTypeName("DataSubTypeRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:43:48.220276849+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class DataSubTypeRequest   {
+  private String id;
+  private String name;
+
+    /**
+     */
+    public DataSubTypeRequest id(String id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     */
+    public DataSubTypeRequest name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DataSubTypeRequest dataSubTypeRequest = (DataSubTypeRequest) o;
+        return Objects.equals(this.id, dataSubTypeRequest.id) &&
+            Objects.equals(this.name, dataSubTypeRequest.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class DataSubTypeRequest {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypesIncludedUnofficialSupportedTypes/expected/src/gen/java/org/openapitools/model/DataSubTypeResponse.java
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypesIncludedUnofficialSupportedTypes/expected/src/gen/java/org/openapitools/model/DataSubTypeResponse.java
@@ -1,0 +1,97 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+
+@JsonTypeName("DataSubTypeResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:43:48.220276849+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class DataSubTypeResponse   {
+  private String id;
+  private String name;
+
+    /**
+     */
+    public DataSubTypeResponse id(String id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     */
+    public DataSubTypeResponse name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DataSubTypeResponse dataSubTypeResponse = (DataSubTypeResponse) o;
+        return Objects.equals(this.id, dataSubTypeResponse.id) &&
+            Objects.equals(this.name, dataSubTypeResponse.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class DataSubTypeResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypesIncludedUnofficialSupportedTypes/expected/src/gen/java/org/openapitools/model/DataTypeRequest.java
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypesIncludedUnofficialSupportedTypes/expected/src/gen/java/org/openapitools/model/DataTypeRequest.java
@@ -1,0 +1,829 @@
+package org.openapitools.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.openapitools.model.DataSubTypeRequest;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+
+@JsonTypeName("DataTypeRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:43:48.220276849+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class DataTypeRequest   {
+  private Integer integerProperty;
+  private Integer integerInt32Property;
+  private Long integerInt64Property;
+  private BigDecimal numberProperty;
+  private Float numberFloatProperty;
+  private Double numberDoubleProperty;
+  private Boolean booleanProperty;
+  private String stringProperty;
+  private byte[] stringByteArrayProperty;
+  private LocalDate stringDateProperty;
+  private String stringTimeProperty;
+  private OffsetDateTime stringDateTimeProperty;
+  private String stringDurationProperty;
+  private String stringPasswordProperty;
+  private BigDecimal stringNumberProperty;
+  private String stringEmailProperty;
+  private String stringIdnEmailProperty;
+  private String stringHostnameProperty;
+  private String stringIdnHostnameProperty;
+  private String stringIpv4Property;
+  private String stringIpv6Property;
+  private UUID stringUuidProperty;
+  private URI stringUriProperty;
+  private String stringUriReferenceProperty;
+  private String stringUriTemplateProperty;
+  private String stringIriProperty;
+  private String stringIriReferenceProperty;
+  private String stringJsonPointerProperty;
+  private String stringRelativeJsonPointerProperty;
+  private String stringRegexProperty;
+  private List<String> arrayProperty = new ArrayList<>();
+  private Set<String> arrayUniqueItemsConstraintProperty = new LinkedHashSet<>();
+  private DataSubTypeRequest objectProperty;
+  private List<DataSubTypeRequest> arrayObjectProperty = new ArrayList<>();
+
+    /**
+     */
+    public DataTypeRequest integerProperty(Integer integerProperty) {
+        this.integerProperty = integerProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerProperty")
+    public Integer getIntegerProperty() {
+        return integerProperty;
+    }
+
+    @JsonProperty("integerProperty")
+    public void setIntegerProperty(Integer integerProperty) {
+        this.integerProperty = integerProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest integerInt32Property(Integer integerInt32Property) {
+        this.integerInt32Property = integerInt32Property;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt32Property")
+    public Integer getIntegerInt32Property() {
+        return integerInt32Property;
+    }
+
+    @JsonProperty("integerInt32Property")
+    public void setIntegerInt32Property(Integer integerInt32Property) {
+        this.integerInt32Property = integerInt32Property;
+    }
+
+    /**
+     */
+    public DataTypeRequest integerInt64Property(Long integerInt64Property) {
+        this.integerInt64Property = integerInt64Property;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt64Property")
+    public Long getIntegerInt64Property() {
+        return integerInt64Property;
+    }
+
+    @JsonProperty("integerInt64Property")
+    public void setIntegerInt64Property(Long integerInt64Property) {
+        this.integerInt64Property = integerInt64Property;
+    }
+
+    /**
+     */
+    public DataTypeRequest numberProperty(BigDecimal numberProperty) {
+        this.numberProperty = numberProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberProperty")
+    public BigDecimal getNumberProperty() {
+        return numberProperty;
+    }
+
+    @JsonProperty("numberProperty")
+    public void setNumberProperty(BigDecimal numberProperty) {
+        this.numberProperty = numberProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest numberFloatProperty(Float numberFloatProperty) {
+        this.numberFloatProperty = numberFloatProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberFloatProperty")
+    public Float getNumberFloatProperty() {
+        return numberFloatProperty;
+    }
+
+    @JsonProperty("numberFloatProperty")
+    public void setNumberFloatProperty(Float numberFloatProperty) {
+        this.numberFloatProperty = numberFloatProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest numberDoubleProperty(Double numberDoubleProperty) {
+        this.numberDoubleProperty = numberDoubleProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberDoubleProperty")
+    public Double getNumberDoubleProperty() {
+        return numberDoubleProperty;
+    }
+
+    @JsonProperty("numberDoubleProperty")
+    public void setNumberDoubleProperty(Double numberDoubleProperty) {
+        this.numberDoubleProperty = numberDoubleProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest booleanProperty(Boolean booleanProperty) {
+        this.booleanProperty = booleanProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("booleanProperty")
+    public Boolean getBooleanProperty() {
+        return booleanProperty;
+    }
+
+    @JsonProperty("booleanProperty")
+    public void setBooleanProperty(Boolean booleanProperty) {
+        this.booleanProperty = booleanProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringProperty(String stringProperty) {
+        this.stringProperty = stringProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringProperty")
+    public String getStringProperty() {
+        return stringProperty;
+    }
+
+    @JsonProperty("stringProperty")
+    public void setStringProperty(String stringProperty) {
+        this.stringProperty = stringProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringByteArrayProperty(byte[] stringByteArrayProperty) {
+        this.stringByteArrayProperty = stringByteArrayProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringByteArrayProperty")
+    public byte[] getStringByteArrayProperty() {
+        return stringByteArrayProperty;
+    }
+
+    @JsonProperty("stringByteArrayProperty")
+    public void setStringByteArrayProperty(byte[] stringByteArrayProperty) {
+        this.stringByteArrayProperty = stringByteArrayProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringDateProperty(LocalDate stringDateProperty) {
+        this.stringDateProperty = stringDateProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringDateProperty")
+    public LocalDate getStringDateProperty() {
+        return stringDateProperty;
+    }
+
+    @JsonProperty("stringDateProperty")
+    public void setStringDateProperty(LocalDate stringDateProperty) {
+        this.stringDateProperty = stringDateProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringTimeProperty(String stringTimeProperty) {
+        this.stringTimeProperty = stringTimeProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringTimeProperty")
+    public String getStringTimeProperty() {
+        return stringTimeProperty;
+    }
+
+    @JsonProperty("stringTimeProperty")
+    public void setStringTimeProperty(String stringTimeProperty) {
+        this.stringTimeProperty = stringTimeProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringDateTimeProperty(OffsetDateTime stringDateTimeProperty) {
+        this.stringDateTimeProperty = stringDateTimeProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringDateTimeProperty")
+    public OffsetDateTime getStringDateTimeProperty() {
+        return stringDateTimeProperty;
+    }
+
+    @JsonProperty("stringDateTimeProperty")
+    public void setStringDateTimeProperty(OffsetDateTime stringDateTimeProperty) {
+        this.stringDateTimeProperty = stringDateTimeProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringDurationProperty(String stringDurationProperty) {
+        this.stringDurationProperty = stringDurationProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringDurationProperty")
+    public String getStringDurationProperty() {
+        return stringDurationProperty;
+    }
+
+    @JsonProperty("stringDurationProperty")
+    public void setStringDurationProperty(String stringDurationProperty) {
+        this.stringDurationProperty = stringDurationProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringPasswordProperty(String stringPasswordProperty) {
+        this.stringPasswordProperty = stringPasswordProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringPasswordProperty")
+    public String getStringPasswordProperty() {
+        return stringPasswordProperty;
+    }
+
+    @JsonProperty("stringPasswordProperty")
+    public void setStringPasswordProperty(String stringPasswordProperty) {
+        this.stringPasswordProperty = stringPasswordProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringNumberProperty(BigDecimal stringNumberProperty) {
+        this.stringNumberProperty = stringNumberProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringNumberProperty")
+    public BigDecimal getStringNumberProperty() {
+        return stringNumberProperty;
+    }
+
+    @JsonProperty("stringNumberProperty")
+    public void setStringNumberProperty(BigDecimal stringNumberProperty) {
+        this.stringNumberProperty = stringNumberProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringEmailProperty(String stringEmailProperty) {
+        this.stringEmailProperty = stringEmailProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringEmailProperty")
+    public String getStringEmailProperty() {
+        return stringEmailProperty;
+    }
+
+    @JsonProperty("stringEmailProperty")
+    public void setStringEmailProperty(String stringEmailProperty) {
+        this.stringEmailProperty = stringEmailProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringIdnEmailProperty(String stringIdnEmailProperty) {
+        this.stringIdnEmailProperty = stringIdnEmailProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringIdnEmailProperty")
+    public String getStringIdnEmailProperty() {
+        return stringIdnEmailProperty;
+    }
+
+    @JsonProperty("stringIdnEmailProperty")
+    public void setStringIdnEmailProperty(String stringIdnEmailProperty) {
+        this.stringIdnEmailProperty = stringIdnEmailProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringHostnameProperty(String stringHostnameProperty) {
+        this.stringHostnameProperty = stringHostnameProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringHostnameProperty")
+    public String getStringHostnameProperty() {
+        return stringHostnameProperty;
+    }
+
+    @JsonProperty("stringHostnameProperty")
+    public void setStringHostnameProperty(String stringHostnameProperty) {
+        this.stringHostnameProperty = stringHostnameProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringIdnHostnameProperty(String stringIdnHostnameProperty) {
+        this.stringIdnHostnameProperty = stringIdnHostnameProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringIdnHostnameProperty")
+    public String getStringIdnHostnameProperty() {
+        return stringIdnHostnameProperty;
+    }
+
+    @JsonProperty("stringIdnHostnameProperty")
+    public void setStringIdnHostnameProperty(String stringIdnHostnameProperty) {
+        this.stringIdnHostnameProperty = stringIdnHostnameProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringIpv4Property(String stringIpv4Property) {
+        this.stringIpv4Property = stringIpv4Property;
+        return this;
+    }
+
+    
+    @JsonProperty("stringIpv4Property")
+    public String getStringIpv4Property() {
+        return stringIpv4Property;
+    }
+
+    @JsonProperty("stringIpv4Property")
+    public void setStringIpv4Property(String stringIpv4Property) {
+        this.stringIpv4Property = stringIpv4Property;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringIpv6Property(String stringIpv6Property) {
+        this.stringIpv6Property = stringIpv6Property;
+        return this;
+    }
+
+    
+    @JsonProperty("stringIpv6Property")
+    public String getStringIpv6Property() {
+        return stringIpv6Property;
+    }
+
+    @JsonProperty("stringIpv6Property")
+    public void setStringIpv6Property(String stringIpv6Property) {
+        this.stringIpv6Property = stringIpv6Property;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringUuidProperty(UUID stringUuidProperty) {
+        this.stringUuidProperty = stringUuidProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringUuidProperty")
+    public UUID getStringUuidProperty() {
+        return stringUuidProperty;
+    }
+
+    @JsonProperty("stringUuidProperty")
+    public void setStringUuidProperty(UUID stringUuidProperty) {
+        this.stringUuidProperty = stringUuidProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringUriProperty(URI stringUriProperty) {
+        this.stringUriProperty = stringUriProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringUriProperty")
+    public URI getStringUriProperty() {
+        return stringUriProperty;
+    }
+
+    @JsonProperty("stringUriProperty")
+    public void setStringUriProperty(URI stringUriProperty) {
+        this.stringUriProperty = stringUriProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringUriReferenceProperty(String stringUriReferenceProperty) {
+        this.stringUriReferenceProperty = stringUriReferenceProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringUriReferenceProperty")
+    public String getStringUriReferenceProperty() {
+        return stringUriReferenceProperty;
+    }
+
+    @JsonProperty("stringUriReferenceProperty")
+    public void setStringUriReferenceProperty(String stringUriReferenceProperty) {
+        this.stringUriReferenceProperty = stringUriReferenceProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringUriTemplateProperty(String stringUriTemplateProperty) {
+        this.stringUriTemplateProperty = stringUriTemplateProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringUriTemplateProperty")
+    public String getStringUriTemplateProperty() {
+        return stringUriTemplateProperty;
+    }
+
+    @JsonProperty("stringUriTemplateProperty")
+    public void setStringUriTemplateProperty(String stringUriTemplateProperty) {
+        this.stringUriTemplateProperty = stringUriTemplateProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringIriProperty(String stringIriProperty) {
+        this.stringIriProperty = stringIriProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringIriProperty")
+    public String getStringIriProperty() {
+        return stringIriProperty;
+    }
+
+    @JsonProperty("stringIriProperty")
+    public void setStringIriProperty(String stringIriProperty) {
+        this.stringIriProperty = stringIriProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringIriReferenceProperty(String stringIriReferenceProperty) {
+        this.stringIriReferenceProperty = stringIriReferenceProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringIriReferenceProperty")
+    public String getStringIriReferenceProperty() {
+        return stringIriReferenceProperty;
+    }
+
+    @JsonProperty("stringIriReferenceProperty")
+    public void setStringIriReferenceProperty(String stringIriReferenceProperty) {
+        this.stringIriReferenceProperty = stringIriReferenceProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringJsonPointerProperty(String stringJsonPointerProperty) {
+        this.stringJsonPointerProperty = stringJsonPointerProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringJsonPointerProperty")
+    public String getStringJsonPointerProperty() {
+        return stringJsonPointerProperty;
+    }
+
+    @JsonProperty("stringJsonPointerProperty")
+    public void setStringJsonPointerProperty(String stringJsonPointerProperty) {
+        this.stringJsonPointerProperty = stringJsonPointerProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringRelativeJsonPointerProperty(String stringRelativeJsonPointerProperty) {
+        this.stringRelativeJsonPointerProperty = stringRelativeJsonPointerProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringRelativeJsonPointerProperty")
+    public String getStringRelativeJsonPointerProperty() {
+        return stringRelativeJsonPointerProperty;
+    }
+
+    @JsonProperty("stringRelativeJsonPointerProperty")
+    public void setStringRelativeJsonPointerProperty(String stringRelativeJsonPointerProperty) {
+        this.stringRelativeJsonPointerProperty = stringRelativeJsonPointerProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringRegexProperty(String stringRegexProperty) {
+        this.stringRegexProperty = stringRegexProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringRegexProperty")
+    public String getStringRegexProperty() {
+        return stringRegexProperty;
+    }
+
+    @JsonProperty("stringRegexProperty")
+    public void setStringRegexProperty(String stringRegexProperty) {
+        this.stringRegexProperty = stringRegexProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest arrayProperty(List<String> arrayProperty) {
+        this.arrayProperty = arrayProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayProperty")
+    public List<String> getArrayProperty() {
+        return arrayProperty;
+    }
+
+    @JsonProperty("arrayProperty")
+    public void setArrayProperty(List<String> arrayProperty) {
+        this.arrayProperty = arrayProperty;
+    }
+
+    public DataTypeRequest addArrayPropertyItem(String arrayPropertyItem) {
+        if (this.arrayProperty == null) {
+            this.arrayProperty = new ArrayList<>();
+        }
+
+        this.arrayProperty.add(arrayPropertyItem);
+        return this;
+    }
+
+    public DataTypeRequest removeArrayPropertyItem(String arrayPropertyItem) {
+        if (arrayPropertyItem != null && this.arrayProperty != null) {
+            this.arrayProperty.remove(arrayPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public DataTypeRequest arrayUniqueItemsConstraintProperty(Set<String> arrayUniqueItemsConstraintProperty) {
+        this.arrayUniqueItemsConstraintProperty = arrayUniqueItemsConstraintProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayUniqueItemsConstraintProperty")
+    public Set<String> getArrayUniqueItemsConstraintProperty() {
+        return arrayUniqueItemsConstraintProperty;
+    }
+
+    @JsonProperty("arrayUniqueItemsConstraintProperty")
+    @JsonDeserialize(as = LinkedHashSet.class)
+    public void setArrayUniqueItemsConstraintProperty(Set<String> arrayUniqueItemsConstraintProperty) {
+        this.arrayUniqueItemsConstraintProperty = arrayUniqueItemsConstraintProperty;
+    }
+
+    public DataTypeRequest addArrayUniqueItemsConstraintPropertyItem(String arrayUniqueItemsConstraintPropertyItem) {
+        if (this.arrayUniqueItemsConstraintProperty == null) {
+            this.arrayUniqueItemsConstraintProperty = new LinkedHashSet<>();
+        }
+
+        this.arrayUniqueItemsConstraintProperty.add(arrayUniqueItemsConstraintPropertyItem);
+        return this;
+    }
+
+    public DataTypeRequest removeArrayUniqueItemsConstraintPropertyItem(String arrayUniqueItemsConstraintPropertyItem) {
+        if (arrayUniqueItemsConstraintPropertyItem != null && this.arrayUniqueItemsConstraintProperty != null) {
+            this.arrayUniqueItemsConstraintProperty.remove(arrayUniqueItemsConstraintPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public DataTypeRequest objectProperty(DataSubTypeRequest objectProperty) {
+        this.objectProperty = objectProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("objectProperty")
+    public DataSubTypeRequest getObjectProperty() {
+        return objectProperty;
+    }
+
+    @JsonProperty("objectProperty")
+    public void setObjectProperty(DataSubTypeRequest objectProperty) {
+        this.objectProperty = objectProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest arrayObjectProperty(List<DataSubTypeRequest> arrayObjectProperty) {
+        this.arrayObjectProperty = arrayObjectProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayObjectProperty")
+    public List<DataSubTypeRequest> getArrayObjectProperty() {
+        return arrayObjectProperty;
+    }
+
+    @JsonProperty("arrayObjectProperty")
+    public void setArrayObjectProperty(List<DataSubTypeRequest> arrayObjectProperty) {
+        this.arrayObjectProperty = arrayObjectProperty;
+    }
+
+    public DataTypeRequest addArrayObjectPropertyItem(DataSubTypeRequest arrayObjectPropertyItem) {
+        if (this.arrayObjectProperty == null) {
+            this.arrayObjectProperty = new ArrayList<>();
+        }
+
+        this.arrayObjectProperty.add(arrayObjectPropertyItem);
+        return this;
+    }
+
+    public DataTypeRequest removeArrayObjectPropertyItem(DataSubTypeRequest arrayObjectPropertyItem) {
+        if (arrayObjectPropertyItem != null && this.arrayObjectProperty != null) {
+            this.arrayObjectProperty.remove(arrayObjectPropertyItem);
+        }
+
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DataTypeRequest dataTypeRequest = (DataTypeRequest) o;
+        return Objects.equals(this.integerProperty, dataTypeRequest.integerProperty) &&
+            Objects.equals(this.integerInt32Property, dataTypeRequest.integerInt32Property) &&
+            Objects.equals(this.integerInt64Property, dataTypeRequest.integerInt64Property) &&
+            Objects.equals(this.numberProperty, dataTypeRequest.numberProperty) &&
+            Objects.equals(this.numberFloatProperty, dataTypeRequest.numberFloatProperty) &&
+            Objects.equals(this.numberDoubleProperty, dataTypeRequest.numberDoubleProperty) &&
+            Objects.equals(this.booleanProperty, dataTypeRequest.booleanProperty) &&
+            Objects.equals(this.stringProperty, dataTypeRequest.stringProperty) &&
+            Arrays.equals(this.stringByteArrayProperty, dataTypeRequest.stringByteArrayProperty) &&
+            Objects.equals(this.stringDateProperty, dataTypeRequest.stringDateProperty) &&
+            Objects.equals(this.stringTimeProperty, dataTypeRequest.stringTimeProperty) &&
+            Objects.equals(this.stringDateTimeProperty, dataTypeRequest.stringDateTimeProperty) &&
+            Objects.equals(this.stringDurationProperty, dataTypeRequest.stringDurationProperty) &&
+            Objects.equals(this.stringPasswordProperty, dataTypeRequest.stringPasswordProperty) &&
+            Objects.equals(this.stringNumberProperty, dataTypeRequest.stringNumberProperty) &&
+            Objects.equals(this.stringEmailProperty, dataTypeRequest.stringEmailProperty) &&
+            Objects.equals(this.stringIdnEmailProperty, dataTypeRequest.stringIdnEmailProperty) &&
+            Objects.equals(this.stringHostnameProperty, dataTypeRequest.stringHostnameProperty) &&
+            Objects.equals(this.stringIdnHostnameProperty, dataTypeRequest.stringIdnHostnameProperty) &&
+            Objects.equals(this.stringIpv4Property, dataTypeRequest.stringIpv4Property) &&
+            Objects.equals(this.stringIpv6Property, dataTypeRequest.stringIpv6Property) &&
+            Objects.equals(this.stringUuidProperty, dataTypeRequest.stringUuidProperty) &&
+            Objects.equals(this.stringUriProperty, dataTypeRequest.stringUriProperty) &&
+            Objects.equals(this.stringUriReferenceProperty, dataTypeRequest.stringUriReferenceProperty) &&
+            Objects.equals(this.stringUriTemplateProperty, dataTypeRequest.stringUriTemplateProperty) &&
+            Objects.equals(this.stringIriProperty, dataTypeRequest.stringIriProperty) &&
+            Objects.equals(this.stringIriReferenceProperty, dataTypeRequest.stringIriReferenceProperty) &&
+            Objects.equals(this.stringJsonPointerProperty, dataTypeRequest.stringJsonPointerProperty) &&
+            Objects.equals(this.stringRelativeJsonPointerProperty, dataTypeRequest.stringRelativeJsonPointerProperty) &&
+            Objects.equals(this.stringRegexProperty, dataTypeRequest.stringRegexProperty) &&
+            Objects.equals(this.arrayProperty, dataTypeRequest.arrayProperty) &&
+            Objects.equals(this.arrayUniqueItemsConstraintProperty, dataTypeRequest.arrayUniqueItemsConstraintProperty) &&
+            Objects.equals(this.objectProperty, dataTypeRequest.objectProperty) &&
+            Objects.equals(this.arrayObjectProperty, dataTypeRequest.arrayObjectProperty);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(integerProperty, integerInt32Property, integerInt64Property, numberProperty, numberFloatProperty, numberDoubleProperty, booleanProperty, stringProperty, Arrays.hashCode(stringByteArrayProperty), stringDateProperty, stringTimeProperty, stringDateTimeProperty, stringDurationProperty, stringPasswordProperty, stringNumberProperty, stringEmailProperty, stringIdnEmailProperty, stringHostnameProperty, stringIdnHostnameProperty, stringIpv4Property, stringIpv6Property, stringUuidProperty, stringUriProperty, stringUriReferenceProperty, stringUriTemplateProperty, stringIriProperty, stringIriReferenceProperty, stringJsonPointerProperty, stringRelativeJsonPointerProperty, stringRegexProperty, arrayProperty, arrayUniqueItemsConstraintProperty, objectProperty, arrayObjectProperty);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class DataTypeRequest {\n");
+        
+        sb.append("    integerProperty: ").append(toIndentedString(integerProperty)).append("\n");
+        sb.append("    integerInt32Property: ").append(toIndentedString(integerInt32Property)).append("\n");
+        sb.append("    integerInt64Property: ").append(toIndentedString(integerInt64Property)).append("\n");
+        sb.append("    numberProperty: ").append(toIndentedString(numberProperty)).append("\n");
+        sb.append("    numberFloatProperty: ").append(toIndentedString(numberFloatProperty)).append("\n");
+        sb.append("    numberDoubleProperty: ").append(toIndentedString(numberDoubleProperty)).append("\n");
+        sb.append("    booleanProperty: ").append(toIndentedString(booleanProperty)).append("\n");
+        sb.append("    stringProperty: ").append(toIndentedString(stringProperty)).append("\n");
+        sb.append("    stringByteArrayProperty: ").append(toIndentedString(stringByteArrayProperty)).append("\n");
+        sb.append("    stringDateProperty: ").append(toIndentedString(stringDateProperty)).append("\n");
+        sb.append("    stringTimeProperty: ").append(toIndentedString(stringTimeProperty)).append("\n");
+        sb.append("    stringDateTimeProperty: ").append(toIndentedString(stringDateTimeProperty)).append("\n");
+        sb.append("    stringDurationProperty: ").append(toIndentedString(stringDurationProperty)).append("\n");
+        sb.append("    stringPasswordProperty: ").append("*").append("\n");
+        sb.append("    stringNumberProperty: ").append(toIndentedString(stringNumberProperty)).append("\n");
+        sb.append("    stringEmailProperty: ").append(toIndentedString(stringEmailProperty)).append("\n");
+        sb.append("    stringIdnEmailProperty: ").append(toIndentedString(stringIdnEmailProperty)).append("\n");
+        sb.append("    stringHostnameProperty: ").append(toIndentedString(stringHostnameProperty)).append("\n");
+        sb.append("    stringIdnHostnameProperty: ").append(toIndentedString(stringIdnHostnameProperty)).append("\n");
+        sb.append("    stringIpv4Property: ").append(toIndentedString(stringIpv4Property)).append("\n");
+        sb.append("    stringIpv6Property: ").append(toIndentedString(stringIpv6Property)).append("\n");
+        sb.append("    stringUuidProperty: ").append(toIndentedString(stringUuidProperty)).append("\n");
+        sb.append("    stringUriProperty: ").append(toIndentedString(stringUriProperty)).append("\n");
+        sb.append("    stringUriReferenceProperty: ").append(toIndentedString(stringUriReferenceProperty)).append("\n");
+        sb.append("    stringUriTemplateProperty: ").append(toIndentedString(stringUriTemplateProperty)).append("\n");
+        sb.append("    stringIriProperty: ").append(toIndentedString(stringIriProperty)).append("\n");
+        sb.append("    stringIriReferenceProperty: ").append(toIndentedString(stringIriReferenceProperty)).append("\n");
+        sb.append("    stringJsonPointerProperty: ").append(toIndentedString(stringJsonPointerProperty)).append("\n");
+        sb.append("    stringRelativeJsonPointerProperty: ").append(toIndentedString(stringRelativeJsonPointerProperty)).append("\n");
+        sb.append("    stringRegexProperty: ").append(toIndentedString(stringRegexProperty)).append("\n");
+        sb.append("    arrayProperty: ").append(toIndentedString(arrayProperty)).append("\n");
+        sb.append("    arrayUniqueItemsConstraintProperty: ").append(toIndentedString(arrayUniqueItemsConstraintProperty)).append("\n");
+        sb.append("    objectProperty: ").append(toIndentedString(objectProperty)).append("\n");
+        sb.append("    arrayObjectProperty: ").append(toIndentedString(arrayObjectProperty)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypesIncludedUnofficialSupportedTypes/expected/src/gen/java/org/openapitools/model/DataTypeResponse.java
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypesIncludedUnofficialSupportedTypes/expected/src/gen/java/org/openapitools/model/DataTypeResponse.java
@@ -1,0 +1,829 @@
+package org.openapitools.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.openapitools.model.DataSubTypeResponse;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+
+@JsonTypeName("DataTypeResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:43:48.220276849+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class DataTypeResponse   {
+  private Integer integerProperty;
+  private Integer integerInt32Property;
+  private Long integerInt64Property;
+  private BigDecimal numberProperty;
+  private Float numberFloatProperty;
+  private Double numberDoubleProperty;
+  private Boolean booleanProperty;
+  private String stringProperty;
+  private byte[] stringByteArrayProperty;
+  private LocalDate stringDateProperty;
+  private String stringTimeProperty;
+  private OffsetDateTime stringDateTimeProperty;
+  private String stringDurationProperty;
+  private String stringPasswordProperty;
+  private BigDecimal stringNumberProperty;
+  private String stringEmailProperty;
+  private String stringIdnEmailProperty;
+  private String stringHostnameProperty;
+  private String stringIdnHostnameProperty;
+  private String stringIpv4Property;
+  private String stringIpv6Property;
+  private UUID stringUuidProperty;
+  private URI stringUriProperty;
+  private String stringUriReferenceProperty;
+  private String stringUriTemplateProperty;
+  private String stringIriProperty;
+  private String stringIriReferenceProperty;
+  private String stringJsonPointerProperty;
+  private String stringRelativeJsonPointerProperty;
+  private String stringRegexProperty;
+  private List<String> arrayProperty = new ArrayList<>();
+  private Set<String> arrayUniqueItemsConstraintProperty = new LinkedHashSet<>();
+  private DataSubTypeResponse objectProperty;
+  private List<DataSubTypeResponse> arrayObjectProperty = new ArrayList<>();
+
+    /**
+     */
+    public DataTypeResponse integerProperty(Integer integerProperty) {
+        this.integerProperty = integerProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerProperty")
+    public Integer getIntegerProperty() {
+        return integerProperty;
+    }
+
+    @JsonProperty("integerProperty")
+    public void setIntegerProperty(Integer integerProperty) {
+        this.integerProperty = integerProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse integerInt32Property(Integer integerInt32Property) {
+        this.integerInt32Property = integerInt32Property;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt32Property")
+    public Integer getIntegerInt32Property() {
+        return integerInt32Property;
+    }
+
+    @JsonProperty("integerInt32Property")
+    public void setIntegerInt32Property(Integer integerInt32Property) {
+        this.integerInt32Property = integerInt32Property;
+    }
+
+    /**
+     */
+    public DataTypeResponse integerInt64Property(Long integerInt64Property) {
+        this.integerInt64Property = integerInt64Property;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt64Property")
+    public Long getIntegerInt64Property() {
+        return integerInt64Property;
+    }
+
+    @JsonProperty("integerInt64Property")
+    public void setIntegerInt64Property(Long integerInt64Property) {
+        this.integerInt64Property = integerInt64Property;
+    }
+
+    /**
+     */
+    public DataTypeResponse numberProperty(BigDecimal numberProperty) {
+        this.numberProperty = numberProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberProperty")
+    public BigDecimal getNumberProperty() {
+        return numberProperty;
+    }
+
+    @JsonProperty("numberProperty")
+    public void setNumberProperty(BigDecimal numberProperty) {
+        this.numberProperty = numberProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse numberFloatProperty(Float numberFloatProperty) {
+        this.numberFloatProperty = numberFloatProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberFloatProperty")
+    public Float getNumberFloatProperty() {
+        return numberFloatProperty;
+    }
+
+    @JsonProperty("numberFloatProperty")
+    public void setNumberFloatProperty(Float numberFloatProperty) {
+        this.numberFloatProperty = numberFloatProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse numberDoubleProperty(Double numberDoubleProperty) {
+        this.numberDoubleProperty = numberDoubleProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberDoubleProperty")
+    public Double getNumberDoubleProperty() {
+        return numberDoubleProperty;
+    }
+
+    @JsonProperty("numberDoubleProperty")
+    public void setNumberDoubleProperty(Double numberDoubleProperty) {
+        this.numberDoubleProperty = numberDoubleProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse booleanProperty(Boolean booleanProperty) {
+        this.booleanProperty = booleanProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("booleanProperty")
+    public Boolean getBooleanProperty() {
+        return booleanProperty;
+    }
+
+    @JsonProperty("booleanProperty")
+    public void setBooleanProperty(Boolean booleanProperty) {
+        this.booleanProperty = booleanProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringProperty(String stringProperty) {
+        this.stringProperty = stringProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringProperty")
+    public String getStringProperty() {
+        return stringProperty;
+    }
+
+    @JsonProperty("stringProperty")
+    public void setStringProperty(String stringProperty) {
+        this.stringProperty = stringProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringByteArrayProperty(byte[] stringByteArrayProperty) {
+        this.stringByteArrayProperty = stringByteArrayProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringByteArrayProperty")
+    public byte[] getStringByteArrayProperty() {
+        return stringByteArrayProperty;
+    }
+
+    @JsonProperty("stringByteArrayProperty")
+    public void setStringByteArrayProperty(byte[] stringByteArrayProperty) {
+        this.stringByteArrayProperty = stringByteArrayProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringDateProperty(LocalDate stringDateProperty) {
+        this.stringDateProperty = stringDateProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringDateProperty")
+    public LocalDate getStringDateProperty() {
+        return stringDateProperty;
+    }
+
+    @JsonProperty("stringDateProperty")
+    public void setStringDateProperty(LocalDate stringDateProperty) {
+        this.stringDateProperty = stringDateProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringTimeProperty(String stringTimeProperty) {
+        this.stringTimeProperty = stringTimeProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringTimeProperty")
+    public String getStringTimeProperty() {
+        return stringTimeProperty;
+    }
+
+    @JsonProperty("stringTimeProperty")
+    public void setStringTimeProperty(String stringTimeProperty) {
+        this.stringTimeProperty = stringTimeProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringDateTimeProperty(OffsetDateTime stringDateTimeProperty) {
+        this.stringDateTimeProperty = stringDateTimeProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringDateTimeProperty")
+    public OffsetDateTime getStringDateTimeProperty() {
+        return stringDateTimeProperty;
+    }
+
+    @JsonProperty("stringDateTimeProperty")
+    public void setStringDateTimeProperty(OffsetDateTime stringDateTimeProperty) {
+        this.stringDateTimeProperty = stringDateTimeProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringDurationProperty(String stringDurationProperty) {
+        this.stringDurationProperty = stringDurationProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringDurationProperty")
+    public String getStringDurationProperty() {
+        return stringDurationProperty;
+    }
+
+    @JsonProperty("stringDurationProperty")
+    public void setStringDurationProperty(String stringDurationProperty) {
+        this.stringDurationProperty = stringDurationProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringPasswordProperty(String stringPasswordProperty) {
+        this.stringPasswordProperty = stringPasswordProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringPasswordProperty")
+    public String getStringPasswordProperty() {
+        return stringPasswordProperty;
+    }
+
+    @JsonProperty("stringPasswordProperty")
+    public void setStringPasswordProperty(String stringPasswordProperty) {
+        this.stringPasswordProperty = stringPasswordProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringNumberProperty(BigDecimal stringNumberProperty) {
+        this.stringNumberProperty = stringNumberProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringNumberProperty")
+    public BigDecimal getStringNumberProperty() {
+        return stringNumberProperty;
+    }
+
+    @JsonProperty("stringNumberProperty")
+    public void setStringNumberProperty(BigDecimal stringNumberProperty) {
+        this.stringNumberProperty = stringNumberProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringEmailProperty(String stringEmailProperty) {
+        this.stringEmailProperty = stringEmailProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringEmailProperty")
+    public String getStringEmailProperty() {
+        return stringEmailProperty;
+    }
+
+    @JsonProperty("stringEmailProperty")
+    public void setStringEmailProperty(String stringEmailProperty) {
+        this.stringEmailProperty = stringEmailProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringIdnEmailProperty(String stringIdnEmailProperty) {
+        this.stringIdnEmailProperty = stringIdnEmailProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringIdnEmailProperty")
+    public String getStringIdnEmailProperty() {
+        return stringIdnEmailProperty;
+    }
+
+    @JsonProperty("stringIdnEmailProperty")
+    public void setStringIdnEmailProperty(String stringIdnEmailProperty) {
+        this.stringIdnEmailProperty = stringIdnEmailProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringHostnameProperty(String stringHostnameProperty) {
+        this.stringHostnameProperty = stringHostnameProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringHostnameProperty")
+    public String getStringHostnameProperty() {
+        return stringHostnameProperty;
+    }
+
+    @JsonProperty("stringHostnameProperty")
+    public void setStringHostnameProperty(String stringHostnameProperty) {
+        this.stringHostnameProperty = stringHostnameProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringIdnHostnameProperty(String stringIdnHostnameProperty) {
+        this.stringIdnHostnameProperty = stringIdnHostnameProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringIdnHostnameProperty")
+    public String getStringIdnHostnameProperty() {
+        return stringIdnHostnameProperty;
+    }
+
+    @JsonProperty("stringIdnHostnameProperty")
+    public void setStringIdnHostnameProperty(String stringIdnHostnameProperty) {
+        this.stringIdnHostnameProperty = stringIdnHostnameProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringIpv4Property(String stringIpv4Property) {
+        this.stringIpv4Property = stringIpv4Property;
+        return this;
+    }
+
+    
+    @JsonProperty("stringIpv4Property")
+    public String getStringIpv4Property() {
+        return stringIpv4Property;
+    }
+
+    @JsonProperty("stringIpv4Property")
+    public void setStringIpv4Property(String stringIpv4Property) {
+        this.stringIpv4Property = stringIpv4Property;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringIpv6Property(String stringIpv6Property) {
+        this.stringIpv6Property = stringIpv6Property;
+        return this;
+    }
+
+    
+    @JsonProperty("stringIpv6Property")
+    public String getStringIpv6Property() {
+        return stringIpv6Property;
+    }
+
+    @JsonProperty("stringIpv6Property")
+    public void setStringIpv6Property(String stringIpv6Property) {
+        this.stringIpv6Property = stringIpv6Property;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringUuidProperty(UUID stringUuidProperty) {
+        this.stringUuidProperty = stringUuidProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringUuidProperty")
+    public UUID getStringUuidProperty() {
+        return stringUuidProperty;
+    }
+
+    @JsonProperty("stringUuidProperty")
+    public void setStringUuidProperty(UUID stringUuidProperty) {
+        this.stringUuidProperty = stringUuidProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringUriProperty(URI stringUriProperty) {
+        this.stringUriProperty = stringUriProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringUriProperty")
+    public URI getStringUriProperty() {
+        return stringUriProperty;
+    }
+
+    @JsonProperty("stringUriProperty")
+    public void setStringUriProperty(URI stringUriProperty) {
+        this.stringUriProperty = stringUriProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringUriReferenceProperty(String stringUriReferenceProperty) {
+        this.stringUriReferenceProperty = stringUriReferenceProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringUriReferenceProperty")
+    public String getStringUriReferenceProperty() {
+        return stringUriReferenceProperty;
+    }
+
+    @JsonProperty("stringUriReferenceProperty")
+    public void setStringUriReferenceProperty(String stringUriReferenceProperty) {
+        this.stringUriReferenceProperty = stringUriReferenceProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringUriTemplateProperty(String stringUriTemplateProperty) {
+        this.stringUriTemplateProperty = stringUriTemplateProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringUriTemplateProperty")
+    public String getStringUriTemplateProperty() {
+        return stringUriTemplateProperty;
+    }
+
+    @JsonProperty("stringUriTemplateProperty")
+    public void setStringUriTemplateProperty(String stringUriTemplateProperty) {
+        this.stringUriTemplateProperty = stringUriTemplateProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringIriProperty(String stringIriProperty) {
+        this.stringIriProperty = stringIriProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringIriProperty")
+    public String getStringIriProperty() {
+        return stringIriProperty;
+    }
+
+    @JsonProperty("stringIriProperty")
+    public void setStringIriProperty(String stringIriProperty) {
+        this.stringIriProperty = stringIriProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringIriReferenceProperty(String stringIriReferenceProperty) {
+        this.stringIriReferenceProperty = stringIriReferenceProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringIriReferenceProperty")
+    public String getStringIriReferenceProperty() {
+        return stringIriReferenceProperty;
+    }
+
+    @JsonProperty("stringIriReferenceProperty")
+    public void setStringIriReferenceProperty(String stringIriReferenceProperty) {
+        this.stringIriReferenceProperty = stringIriReferenceProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringJsonPointerProperty(String stringJsonPointerProperty) {
+        this.stringJsonPointerProperty = stringJsonPointerProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringJsonPointerProperty")
+    public String getStringJsonPointerProperty() {
+        return stringJsonPointerProperty;
+    }
+
+    @JsonProperty("stringJsonPointerProperty")
+    public void setStringJsonPointerProperty(String stringJsonPointerProperty) {
+        this.stringJsonPointerProperty = stringJsonPointerProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringRelativeJsonPointerProperty(String stringRelativeJsonPointerProperty) {
+        this.stringRelativeJsonPointerProperty = stringRelativeJsonPointerProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringRelativeJsonPointerProperty")
+    public String getStringRelativeJsonPointerProperty() {
+        return stringRelativeJsonPointerProperty;
+    }
+
+    @JsonProperty("stringRelativeJsonPointerProperty")
+    public void setStringRelativeJsonPointerProperty(String stringRelativeJsonPointerProperty) {
+        this.stringRelativeJsonPointerProperty = stringRelativeJsonPointerProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringRegexProperty(String stringRegexProperty) {
+        this.stringRegexProperty = stringRegexProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringRegexProperty")
+    public String getStringRegexProperty() {
+        return stringRegexProperty;
+    }
+
+    @JsonProperty("stringRegexProperty")
+    public void setStringRegexProperty(String stringRegexProperty) {
+        this.stringRegexProperty = stringRegexProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse arrayProperty(List<String> arrayProperty) {
+        this.arrayProperty = arrayProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayProperty")
+    public List<String> getArrayProperty() {
+        return arrayProperty;
+    }
+
+    @JsonProperty("arrayProperty")
+    public void setArrayProperty(List<String> arrayProperty) {
+        this.arrayProperty = arrayProperty;
+    }
+
+    public DataTypeResponse addArrayPropertyItem(String arrayPropertyItem) {
+        if (this.arrayProperty == null) {
+            this.arrayProperty = new ArrayList<>();
+        }
+
+        this.arrayProperty.add(arrayPropertyItem);
+        return this;
+    }
+
+    public DataTypeResponse removeArrayPropertyItem(String arrayPropertyItem) {
+        if (arrayPropertyItem != null && this.arrayProperty != null) {
+            this.arrayProperty.remove(arrayPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public DataTypeResponse arrayUniqueItemsConstraintProperty(Set<String> arrayUniqueItemsConstraintProperty) {
+        this.arrayUniqueItemsConstraintProperty = arrayUniqueItemsConstraintProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayUniqueItemsConstraintProperty")
+    public Set<String> getArrayUniqueItemsConstraintProperty() {
+        return arrayUniqueItemsConstraintProperty;
+    }
+
+    @JsonProperty("arrayUniqueItemsConstraintProperty")
+    @JsonDeserialize(as = LinkedHashSet.class)
+    public void setArrayUniqueItemsConstraintProperty(Set<String> arrayUniqueItemsConstraintProperty) {
+        this.arrayUniqueItemsConstraintProperty = arrayUniqueItemsConstraintProperty;
+    }
+
+    public DataTypeResponse addArrayUniqueItemsConstraintPropertyItem(String arrayUniqueItemsConstraintPropertyItem) {
+        if (this.arrayUniqueItemsConstraintProperty == null) {
+            this.arrayUniqueItemsConstraintProperty = new LinkedHashSet<>();
+        }
+
+        this.arrayUniqueItemsConstraintProperty.add(arrayUniqueItemsConstraintPropertyItem);
+        return this;
+    }
+
+    public DataTypeResponse removeArrayUniqueItemsConstraintPropertyItem(String arrayUniqueItemsConstraintPropertyItem) {
+        if (arrayUniqueItemsConstraintPropertyItem != null && this.arrayUniqueItemsConstraintProperty != null) {
+            this.arrayUniqueItemsConstraintProperty.remove(arrayUniqueItemsConstraintPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public DataTypeResponse objectProperty(DataSubTypeResponse objectProperty) {
+        this.objectProperty = objectProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("objectProperty")
+    public DataSubTypeResponse getObjectProperty() {
+        return objectProperty;
+    }
+
+    @JsonProperty("objectProperty")
+    public void setObjectProperty(DataSubTypeResponse objectProperty) {
+        this.objectProperty = objectProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse arrayObjectProperty(List<DataSubTypeResponse> arrayObjectProperty) {
+        this.arrayObjectProperty = arrayObjectProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayObjectProperty")
+    public List<DataSubTypeResponse> getArrayObjectProperty() {
+        return arrayObjectProperty;
+    }
+
+    @JsonProperty("arrayObjectProperty")
+    public void setArrayObjectProperty(List<DataSubTypeResponse> arrayObjectProperty) {
+        this.arrayObjectProperty = arrayObjectProperty;
+    }
+
+    public DataTypeResponse addArrayObjectPropertyItem(DataSubTypeResponse arrayObjectPropertyItem) {
+        if (this.arrayObjectProperty == null) {
+            this.arrayObjectProperty = new ArrayList<>();
+        }
+
+        this.arrayObjectProperty.add(arrayObjectPropertyItem);
+        return this;
+    }
+
+    public DataTypeResponse removeArrayObjectPropertyItem(DataSubTypeResponse arrayObjectPropertyItem) {
+        if (arrayObjectPropertyItem != null && this.arrayObjectProperty != null) {
+            this.arrayObjectProperty.remove(arrayObjectPropertyItem);
+        }
+
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DataTypeResponse dataTypeResponse = (DataTypeResponse) o;
+        return Objects.equals(this.integerProperty, dataTypeResponse.integerProperty) &&
+            Objects.equals(this.integerInt32Property, dataTypeResponse.integerInt32Property) &&
+            Objects.equals(this.integerInt64Property, dataTypeResponse.integerInt64Property) &&
+            Objects.equals(this.numberProperty, dataTypeResponse.numberProperty) &&
+            Objects.equals(this.numberFloatProperty, dataTypeResponse.numberFloatProperty) &&
+            Objects.equals(this.numberDoubleProperty, dataTypeResponse.numberDoubleProperty) &&
+            Objects.equals(this.booleanProperty, dataTypeResponse.booleanProperty) &&
+            Objects.equals(this.stringProperty, dataTypeResponse.stringProperty) &&
+            Arrays.equals(this.stringByteArrayProperty, dataTypeResponse.stringByteArrayProperty) &&
+            Objects.equals(this.stringDateProperty, dataTypeResponse.stringDateProperty) &&
+            Objects.equals(this.stringTimeProperty, dataTypeResponse.stringTimeProperty) &&
+            Objects.equals(this.stringDateTimeProperty, dataTypeResponse.stringDateTimeProperty) &&
+            Objects.equals(this.stringDurationProperty, dataTypeResponse.stringDurationProperty) &&
+            Objects.equals(this.stringPasswordProperty, dataTypeResponse.stringPasswordProperty) &&
+            Objects.equals(this.stringNumberProperty, dataTypeResponse.stringNumberProperty) &&
+            Objects.equals(this.stringEmailProperty, dataTypeResponse.stringEmailProperty) &&
+            Objects.equals(this.stringIdnEmailProperty, dataTypeResponse.stringIdnEmailProperty) &&
+            Objects.equals(this.stringHostnameProperty, dataTypeResponse.stringHostnameProperty) &&
+            Objects.equals(this.stringIdnHostnameProperty, dataTypeResponse.stringIdnHostnameProperty) &&
+            Objects.equals(this.stringIpv4Property, dataTypeResponse.stringIpv4Property) &&
+            Objects.equals(this.stringIpv6Property, dataTypeResponse.stringIpv6Property) &&
+            Objects.equals(this.stringUuidProperty, dataTypeResponse.stringUuidProperty) &&
+            Objects.equals(this.stringUriProperty, dataTypeResponse.stringUriProperty) &&
+            Objects.equals(this.stringUriReferenceProperty, dataTypeResponse.stringUriReferenceProperty) &&
+            Objects.equals(this.stringUriTemplateProperty, dataTypeResponse.stringUriTemplateProperty) &&
+            Objects.equals(this.stringIriProperty, dataTypeResponse.stringIriProperty) &&
+            Objects.equals(this.stringIriReferenceProperty, dataTypeResponse.stringIriReferenceProperty) &&
+            Objects.equals(this.stringJsonPointerProperty, dataTypeResponse.stringJsonPointerProperty) &&
+            Objects.equals(this.stringRelativeJsonPointerProperty, dataTypeResponse.stringRelativeJsonPointerProperty) &&
+            Objects.equals(this.stringRegexProperty, dataTypeResponse.stringRegexProperty) &&
+            Objects.equals(this.arrayProperty, dataTypeResponse.arrayProperty) &&
+            Objects.equals(this.arrayUniqueItemsConstraintProperty, dataTypeResponse.arrayUniqueItemsConstraintProperty) &&
+            Objects.equals(this.objectProperty, dataTypeResponse.objectProperty) &&
+            Objects.equals(this.arrayObjectProperty, dataTypeResponse.arrayObjectProperty);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(integerProperty, integerInt32Property, integerInt64Property, numberProperty, numberFloatProperty, numberDoubleProperty, booleanProperty, stringProperty, Arrays.hashCode(stringByteArrayProperty), stringDateProperty, stringTimeProperty, stringDateTimeProperty, stringDurationProperty, stringPasswordProperty, stringNumberProperty, stringEmailProperty, stringIdnEmailProperty, stringHostnameProperty, stringIdnHostnameProperty, stringIpv4Property, stringIpv6Property, stringUuidProperty, stringUriProperty, stringUriReferenceProperty, stringUriTemplateProperty, stringIriProperty, stringIriReferenceProperty, stringJsonPointerProperty, stringRelativeJsonPointerProperty, stringRegexProperty, arrayProperty, arrayUniqueItemsConstraintProperty, objectProperty, arrayObjectProperty);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class DataTypeResponse {\n");
+        
+        sb.append("    integerProperty: ").append(toIndentedString(integerProperty)).append("\n");
+        sb.append("    integerInt32Property: ").append(toIndentedString(integerInt32Property)).append("\n");
+        sb.append("    integerInt64Property: ").append(toIndentedString(integerInt64Property)).append("\n");
+        sb.append("    numberProperty: ").append(toIndentedString(numberProperty)).append("\n");
+        sb.append("    numberFloatProperty: ").append(toIndentedString(numberFloatProperty)).append("\n");
+        sb.append("    numberDoubleProperty: ").append(toIndentedString(numberDoubleProperty)).append("\n");
+        sb.append("    booleanProperty: ").append(toIndentedString(booleanProperty)).append("\n");
+        sb.append("    stringProperty: ").append(toIndentedString(stringProperty)).append("\n");
+        sb.append("    stringByteArrayProperty: ").append(toIndentedString(stringByteArrayProperty)).append("\n");
+        sb.append("    stringDateProperty: ").append(toIndentedString(stringDateProperty)).append("\n");
+        sb.append("    stringTimeProperty: ").append(toIndentedString(stringTimeProperty)).append("\n");
+        sb.append("    stringDateTimeProperty: ").append(toIndentedString(stringDateTimeProperty)).append("\n");
+        sb.append("    stringDurationProperty: ").append(toIndentedString(stringDurationProperty)).append("\n");
+        sb.append("    stringPasswordProperty: ").append("*").append("\n");
+        sb.append("    stringNumberProperty: ").append(toIndentedString(stringNumberProperty)).append("\n");
+        sb.append("    stringEmailProperty: ").append(toIndentedString(stringEmailProperty)).append("\n");
+        sb.append("    stringIdnEmailProperty: ").append(toIndentedString(stringIdnEmailProperty)).append("\n");
+        sb.append("    stringHostnameProperty: ").append(toIndentedString(stringHostnameProperty)).append("\n");
+        sb.append("    stringIdnHostnameProperty: ").append(toIndentedString(stringIdnHostnameProperty)).append("\n");
+        sb.append("    stringIpv4Property: ").append(toIndentedString(stringIpv4Property)).append("\n");
+        sb.append("    stringIpv6Property: ").append(toIndentedString(stringIpv6Property)).append("\n");
+        sb.append("    stringUuidProperty: ").append(toIndentedString(stringUuidProperty)).append("\n");
+        sb.append("    stringUriProperty: ").append(toIndentedString(stringUriProperty)).append("\n");
+        sb.append("    stringUriReferenceProperty: ").append(toIndentedString(stringUriReferenceProperty)).append("\n");
+        sb.append("    stringUriTemplateProperty: ").append(toIndentedString(stringUriTemplateProperty)).append("\n");
+        sb.append("    stringIriProperty: ").append(toIndentedString(stringIriProperty)).append("\n");
+        sb.append("    stringIriReferenceProperty: ").append(toIndentedString(stringIriReferenceProperty)).append("\n");
+        sb.append("    stringJsonPointerProperty: ").append(toIndentedString(stringJsonPointerProperty)).append("\n");
+        sb.append("    stringRelativeJsonPointerProperty: ").append(toIndentedString(stringRelativeJsonPointerProperty)).append("\n");
+        sb.append("    stringRegexProperty: ").append(toIndentedString(stringRegexProperty)).append("\n");
+        sb.append("    arrayProperty: ").append(toIndentedString(arrayProperty)).append("\n");
+        sb.append("    arrayUniqueItemsConstraintProperty: ").append(toIndentedString(arrayUniqueItemsConstraintProperty)).append("\n");
+        sb.append("    objectProperty: ").append(toIndentedString(objectProperty)).append("\n");
+        sb.append("    arrayObjectProperty: ").append(toIndentedString(arrayObjectProperty)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypesPrimitivePropertiesAsString/expected/src/gen/java/org/openapitools/api/DataTypesApi.java
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypesPrimitivePropertiesAsString/expected/src/gen/java/org/openapitools/api/DataTypesApi.java
@@ -1,0 +1,42 @@
+package org.openapitools.api;
+
+import org.openapitools.model.DataTypeRequest;
+import org.openapitools.model.DataTypeResponse;
+import nablarch.fw.jaxrs.EntityResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+
+import jakarta.ws.rs.*;
+
+@Path("/data-types")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:43:48.837689355+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface DataTypesApi {
+    /**
+     * GET 
+     *
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return OK
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<DataTypeResponse>> dataTypesGet(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * POST 
+     *
+     *
+     * @param dataTypeRequest 
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return OK
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<DataTypeResponse> dataTypesPost(DataTypeRequest dataTypeRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypesPrimitivePropertiesAsString/expected/src/gen/java/org/openapitools/model/DataSubTypeRequest.java
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypesPrimitivePropertiesAsString/expected/src/gen/java/org/openapitools/model/DataSubTypeRequest.java
@@ -1,0 +1,97 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+
+@JsonTypeName("DataSubTypeRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:43:48.837689355+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class DataSubTypeRequest   {
+  private String id;
+  private String name;
+
+    /**
+     */
+    public DataSubTypeRequest id(String id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     */
+    public DataSubTypeRequest name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DataSubTypeRequest dataSubTypeRequest = (DataSubTypeRequest) o;
+        return Objects.equals(this.id, dataSubTypeRequest.id) &&
+            Objects.equals(this.name, dataSubTypeRequest.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class DataSubTypeRequest {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypesPrimitivePropertiesAsString/expected/src/gen/java/org/openapitools/model/DataSubTypeResponse.java
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypesPrimitivePropertiesAsString/expected/src/gen/java/org/openapitools/model/DataSubTypeResponse.java
@@ -1,0 +1,97 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+
+@JsonTypeName("DataSubTypeResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:43:48.837689355+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class DataSubTypeResponse   {
+  private String id;
+  private String name;
+
+    /**
+     */
+    public DataSubTypeResponse id(String id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     */
+    public DataSubTypeResponse name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DataSubTypeResponse dataSubTypeResponse = (DataSubTypeResponse) o;
+        return Objects.equals(this.id, dataSubTypeResponse.id) &&
+            Objects.equals(this.name, dataSubTypeResponse.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class DataSubTypeResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypesPrimitivePropertiesAsString/expected/src/gen/java/org/openapitools/model/DataTypeRequest.java
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypesPrimitivePropertiesAsString/expected/src/gen/java/org/openapitools/model/DataTypeRequest.java
@@ -1,0 +1,488 @@
+package org.openapitools.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.openapitools.model.DataSubTypeRequest;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+
+@JsonTypeName("DataTypeRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:43:48.837689355+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class DataTypeRequest   {
+  private String integerProperty;
+  private String integerInt32Property;
+  private String integerInt64Property;
+  private String numberProperty;
+  private String numberFloatProperty;
+  private String numberDoubleProperty;
+  private String booleanProperty;
+  private String stringProperty;
+  private String stringByteArrayProperty;
+  private String stringDateProperty;
+  private String stringDateTimeProperty;
+  private String stringNumberProperty;
+  private String stringUuidProperty;
+  private String stringUriProperty;
+  private List<String> arrayProperty = new ArrayList<>();
+  private Set<String> arrayUniqueItemsConstraintProperty = new LinkedHashSet<>();
+  private DataSubTypeRequest objectProperty;
+  private List<DataSubTypeRequest> arrayObjectProperty = new ArrayList<>();
+
+    /**
+     */
+    public DataTypeRequest integerProperty(String integerProperty) {
+        this.integerProperty = integerProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerProperty")
+    public String getIntegerProperty() {
+        return integerProperty;
+    }
+
+    @JsonProperty("integerProperty")
+    public void setIntegerProperty(String integerProperty) {
+        this.integerProperty = integerProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest integerInt32Property(String integerInt32Property) {
+        this.integerInt32Property = integerInt32Property;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt32Property")
+    public String getIntegerInt32Property() {
+        return integerInt32Property;
+    }
+
+    @JsonProperty("integerInt32Property")
+    public void setIntegerInt32Property(String integerInt32Property) {
+        this.integerInt32Property = integerInt32Property;
+    }
+
+    /**
+     */
+    public DataTypeRequest integerInt64Property(String integerInt64Property) {
+        this.integerInt64Property = integerInt64Property;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt64Property")
+    public String getIntegerInt64Property() {
+        return integerInt64Property;
+    }
+
+    @JsonProperty("integerInt64Property")
+    public void setIntegerInt64Property(String integerInt64Property) {
+        this.integerInt64Property = integerInt64Property;
+    }
+
+    /**
+     */
+    public DataTypeRequest numberProperty(String numberProperty) {
+        this.numberProperty = numberProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberProperty")
+    public String getNumberProperty() {
+        return numberProperty;
+    }
+
+    @JsonProperty("numberProperty")
+    public void setNumberProperty(String numberProperty) {
+        this.numberProperty = numberProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest numberFloatProperty(String numberFloatProperty) {
+        this.numberFloatProperty = numberFloatProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberFloatProperty")
+    public String getNumberFloatProperty() {
+        return numberFloatProperty;
+    }
+
+    @JsonProperty("numberFloatProperty")
+    public void setNumberFloatProperty(String numberFloatProperty) {
+        this.numberFloatProperty = numberFloatProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest numberDoubleProperty(String numberDoubleProperty) {
+        this.numberDoubleProperty = numberDoubleProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberDoubleProperty")
+    public String getNumberDoubleProperty() {
+        return numberDoubleProperty;
+    }
+
+    @JsonProperty("numberDoubleProperty")
+    public void setNumberDoubleProperty(String numberDoubleProperty) {
+        this.numberDoubleProperty = numberDoubleProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest booleanProperty(String booleanProperty) {
+        this.booleanProperty = booleanProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("booleanProperty")
+    public String getBooleanProperty() {
+        return booleanProperty;
+    }
+
+    @JsonProperty("booleanProperty")
+    public void setBooleanProperty(String booleanProperty) {
+        this.booleanProperty = booleanProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringProperty(String stringProperty) {
+        this.stringProperty = stringProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringProperty")
+    public String getStringProperty() {
+        return stringProperty;
+    }
+
+    @JsonProperty("stringProperty")
+    public void setStringProperty(String stringProperty) {
+        this.stringProperty = stringProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringByteArrayProperty(String stringByteArrayProperty) {
+        this.stringByteArrayProperty = stringByteArrayProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringByteArrayProperty")
+    public String getStringByteArrayProperty() {
+        return stringByteArrayProperty;
+    }
+
+    @JsonProperty("stringByteArrayProperty")
+    public void setStringByteArrayProperty(String stringByteArrayProperty) {
+        this.stringByteArrayProperty = stringByteArrayProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringDateProperty(String stringDateProperty) {
+        this.stringDateProperty = stringDateProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringDateProperty")
+    public String getStringDateProperty() {
+        return stringDateProperty;
+    }
+
+    @JsonProperty("stringDateProperty")
+    public void setStringDateProperty(String stringDateProperty) {
+        this.stringDateProperty = stringDateProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringDateTimeProperty(String stringDateTimeProperty) {
+        this.stringDateTimeProperty = stringDateTimeProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringDateTimeProperty")
+    public String getStringDateTimeProperty() {
+        return stringDateTimeProperty;
+    }
+
+    @JsonProperty("stringDateTimeProperty")
+    public void setStringDateTimeProperty(String stringDateTimeProperty) {
+        this.stringDateTimeProperty = stringDateTimeProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringNumberProperty(String stringNumberProperty) {
+        this.stringNumberProperty = stringNumberProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringNumberProperty")
+    public String getStringNumberProperty() {
+        return stringNumberProperty;
+    }
+
+    @JsonProperty("stringNumberProperty")
+    public void setStringNumberProperty(String stringNumberProperty) {
+        this.stringNumberProperty = stringNumberProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringUuidProperty(String stringUuidProperty) {
+        this.stringUuidProperty = stringUuidProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringUuidProperty")
+    public String getStringUuidProperty() {
+        return stringUuidProperty;
+    }
+
+    @JsonProperty("stringUuidProperty")
+    public void setStringUuidProperty(String stringUuidProperty) {
+        this.stringUuidProperty = stringUuidProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest stringUriProperty(String stringUriProperty) {
+        this.stringUriProperty = stringUriProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringUriProperty")
+    public String getStringUriProperty() {
+        return stringUriProperty;
+    }
+
+    @JsonProperty("stringUriProperty")
+    public void setStringUriProperty(String stringUriProperty) {
+        this.stringUriProperty = stringUriProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest arrayProperty(List<String> arrayProperty) {
+        this.arrayProperty = arrayProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayProperty")
+    public List<String> getArrayProperty() {
+        return arrayProperty;
+    }
+
+    @JsonProperty("arrayProperty")
+    public void setArrayProperty(List<String> arrayProperty) {
+        this.arrayProperty = arrayProperty;
+    }
+
+    public DataTypeRequest addArrayPropertyItem(String arrayPropertyItem) {
+        if (this.arrayProperty == null) {
+            this.arrayProperty = new ArrayList<>();
+        }
+
+        this.arrayProperty.add(arrayPropertyItem);
+        return this;
+    }
+
+    public DataTypeRequest removeArrayPropertyItem(String arrayPropertyItem) {
+        if (arrayPropertyItem != null && this.arrayProperty != null) {
+            this.arrayProperty.remove(arrayPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public DataTypeRequest arrayUniqueItemsConstraintProperty(Set<String> arrayUniqueItemsConstraintProperty) {
+        this.arrayUniqueItemsConstraintProperty = arrayUniqueItemsConstraintProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayUniqueItemsConstraintProperty")
+    public Set<String> getArrayUniqueItemsConstraintProperty() {
+        return arrayUniqueItemsConstraintProperty;
+    }
+
+    @JsonProperty("arrayUniqueItemsConstraintProperty")
+    @JsonDeserialize(as = LinkedHashSet.class)
+    public void setArrayUniqueItemsConstraintProperty(Set<String> arrayUniqueItemsConstraintProperty) {
+        this.arrayUniqueItemsConstraintProperty = arrayUniqueItemsConstraintProperty;
+    }
+
+    public DataTypeRequest addArrayUniqueItemsConstraintPropertyItem(String arrayUniqueItemsConstraintPropertyItem) {
+        if (this.arrayUniqueItemsConstraintProperty == null) {
+            this.arrayUniqueItemsConstraintProperty = new LinkedHashSet<>();
+        }
+
+        this.arrayUniqueItemsConstraintProperty.add(arrayUniqueItemsConstraintPropertyItem);
+        return this;
+    }
+
+    public DataTypeRequest removeArrayUniqueItemsConstraintPropertyItem(String arrayUniqueItemsConstraintPropertyItem) {
+        if (arrayUniqueItemsConstraintPropertyItem != null && this.arrayUniqueItemsConstraintProperty != null) {
+            this.arrayUniqueItemsConstraintProperty.remove(arrayUniqueItemsConstraintPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public DataTypeRequest objectProperty(DataSubTypeRequest objectProperty) {
+        this.objectProperty = objectProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("objectProperty")
+    public DataSubTypeRequest getObjectProperty() {
+        return objectProperty;
+    }
+
+    @JsonProperty("objectProperty")
+    public void setObjectProperty(DataSubTypeRequest objectProperty) {
+        this.objectProperty = objectProperty;
+    }
+
+    /**
+     */
+    public DataTypeRequest arrayObjectProperty(List<DataSubTypeRequest> arrayObjectProperty) {
+        this.arrayObjectProperty = arrayObjectProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayObjectProperty")
+    public List<DataSubTypeRequest> getArrayObjectProperty() {
+        return arrayObjectProperty;
+    }
+
+    @JsonProperty("arrayObjectProperty")
+    public void setArrayObjectProperty(List<DataSubTypeRequest> arrayObjectProperty) {
+        this.arrayObjectProperty = arrayObjectProperty;
+    }
+
+    public DataTypeRequest addArrayObjectPropertyItem(DataSubTypeRequest arrayObjectPropertyItem) {
+        if (this.arrayObjectProperty == null) {
+            this.arrayObjectProperty = new ArrayList<>();
+        }
+
+        this.arrayObjectProperty.add(arrayObjectPropertyItem);
+        return this;
+    }
+
+    public DataTypeRequest removeArrayObjectPropertyItem(DataSubTypeRequest arrayObjectPropertyItem) {
+        if (arrayObjectPropertyItem != null && this.arrayObjectProperty != null) {
+            this.arrayObjectProperty.remove(arrayObjectPropertyItem);
+        }
+
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DataTypeRequest dataTypeRequest = (DataTypeRequest) o;
+        return Objects.equals(this.integerProperty, dataTypeRequest.integerProperty) &&
+            Objects.equals(this.integerInt32Property, dataTypeRequest.integerInt32Property) &&
+            Objects.equals(this.integerInt64Property, dataTypeRequest.integerInt64Property) &&
+            Objects.equals(this.numberProperty, dataTypeRequest.numberProperty) &&
+            Objects.equals(this.numberFloatProperty, dataTypeRequest.numberFloatProperty) &&
+            Objects.equals(this.numberDoubleProperty, dataTypeRequest.numberDoubleProperty) &&
+            Objects.equals(this.booleanProperty, dataTypeRequest.booleanProperty) &&
+            Objects.equals(this.stringProperty, dataTypeRequest.stringProperty) &&
+            Arrays.equals(this.stringByteArrayProperty, dataTypeRequest.stringByteArrayProperty) &&
+            Objects.equals(this.stringDateProperty, dataTypeRequest.stringDateProperty) &&
+            Objects.equals(this.stringDateTimeProperty, dataTypeRequest.stringDateTimeProperty) &&
+            Objects.equals(this.stringNumberProperty, dataTypeRequest.stringNumberProperty) &&
+            Objects.equals(this.stringUuidProperty, dataTypeRequest.stringUuidProperty) &&
+            Objects.equals(this.stringUriProperty, dataTypeRequest.stringUriProperty) &&
+            Objects.equals(this.arrayProperty, dataTypeRequest.arrayProperty) &&
+            Objects.equals(this.arrayUniqueItemsConstraintProperty, dataTypeRequest.arrayUniqueItemsConstraintProperty) &&
+            Objects.equals(this.objectProperty, dataTypeRequest.objectProperty) &&
+            Objects.equals(this.arrayObjectProperty, dataTypeRequest.arrayObjectProperty);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(integerProperty, integerInt32Property, integerInt64Property, numberProperty, numberFloatProperty, numberDoubleProperty, booleanProperty, stringProperty, Arrays.hashCode(stringByteArrayProperty), stringDateProperty, stringDateTimeProperty, stringNumberProperty, stringUuidProperty, stringUriProperty, arrayProperty, arrayUniqueItemsConstraintProperty, objectProperty, arrayObjectProperty);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class DataTypeRequest {\n");
+        
+        sb.append("    integerProperty: ").append(toIndentedString(integerProperty)).append("\n");
+        sb.append("    integerInt32Property: ").append(toIndentedString(integerInt32Property)).append("\n");
+        sb.append("    integerInt64Property: ").append(toIndentedString(integerInt64Property)).append("\n");
+        sb.append("    numberProperty: ").append(toIndentedString(numberProperty)).append("\n");
+        sb.append("    numberFloatProperty: ").append(toIndentedString(numberFloatProperty)).append("\n");
+        sb.append("    numberDoubleProperty: ").append(toIndentedString(numberDoubleProperty)).append("\n");
+        sb.append("    booleanProperty: ").append(toIndentedString(booleanProperty)).append("\n");
+        sb.append("    stringProperty: ").append(toIndentedString(stringProperty)).append("\n");
+        sb.append("    stringByteArrayProperty: ").append(toIndentedString(stringByteArrayProperty)).append("\n");
+        sb.append("    stringDateProperty: ").append(toIndentedString(stringDateProperty)).append("\n");
+        sb.append("    stringDateTimeProperty: ").append(toIndentedString(stringDateTimeProperty)).append("\n");
+        sb.append("    stringNumberProperty: ").append(toIndentedString(stringNumberProperty)).append("\n");
+        sb.append("    stringUuidProperty: ").append(toIndentedString(stringUuidProperty)).append("\n");
+        sb.append("    stringUriProperty: ").append(toIndentedString(stringUriProperty)).append("\n");
+        sb.append("    arrayProperty: ").append(toIndentedString(arrayProperty)).append("\n");
+        sb.append("    arrayUniqueItemsConstraintProperty: ").append(toIndentedString(arrayUniqueItemsConstraintProperty)).append("\n");
+        sb.append("    objectProperty: ").append(toIndentedString(objectProperty)).append("\n");
+        sb.append("    arrayObjectProperty: ").append(toIndentedString(arrayObjectProperty)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypesPrimitivePropertiesAsString/expected/src/gen/java/org/openapitools/model/DataTypeResponse.java
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/allDataTypesPrimitivePropertiesAsString/expected/src/gen/java/org/openapitools/model/DataTypeResponse.java
@@ -1,0 +1,488 @@
+package org.openapitools.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.openapitools.model.DataSubTypeResponse;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+
+@JsonTypeName("DataTypeResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:43:48.837689355+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class DataTypeResponse   {
+  private String integerProperty;
+  private String integerInt32Property;
+  private String integerInt64Property;
+  private String numberProperty;
+  private String numberFloatProperty;
+  private String numberDoubleProperty;
+  private String booleanProperty;
+  private String stringProperty;
+  private String stringByteArrayProperty;
+  private String stringDateProperty;
+  private String stringDateTimeProperty;
+  private String stringNumberProperty;
+  private String stringUuidProperty;
+  private String stringUriProperty;
+  private List<String> arrayProperty = new ArrayList<>();
+  private Set<String> arrayUniqueItemsConstraintProperty = new LinkedHashSet<>();
+  private DataSubTypeResponse objectProperty;
+  private List<DataSubTypeResponse> arrayObjectProperty = new ArrayList<>();
+
+    /**
+     */
+    public DataTypeResponse integerProperty(String integerProperty) {
+        this.integerProperty = integerProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerProperty")
+    public String getIntegerProperty() {
+        return integerProperty;
+    }
+
+    @JsonProperty("integerProperty")
+    public void setIntegerProperty(String integerProperty) {
+        this.integerProperty = integerProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse integerInt32Property(String integerInt32Property) {
+        this.integerInt32Property = integerInt32Property;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt32Property")
+    public String getIntegerInt32Property() {
+        return integerInt32Property;
+    }
+
+    @JsonProperty("integerInt32Property")
+    public void setIntegerInt32Property(String integerInt32Property) {
+        this.integerInt32Property = integerInt32Property;
+    }
+
+    /**
+     */
+    public DataTypeResponse integerInt64Property(String integerInt64Property) {
+        this.integerInt64Property = integerInt64Property;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt64Property")
+    public String getIntegerInt64Property() {
+        return integerInt64Property;
+    }
+
+    @JsonProperty("integerInt64Property")
+    public void setIntegerInt64Property(String integerInt64Property) {
+        this.integerInt64Property = integerInt64Property;
+    }
+
+    /**
+     */
+    public DataTypeResponse numberProperty(String numberProperty) {
+        this.numberProperty = numberProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberProperty")
+    public String getNumberProperty() {
+        return numberProperty;
+    }
+
+    @JsonProperty("numberProperty")
+    public void setNumberProperty(String numberProperty) {
+        this.numberProperty = numberProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse numberFloatProperty(String numberFloatProperty) {
+        this.numberFloatProperty = numberFloatProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberFloatProperty")
+    public String getNumberFloatProperty() {
+        return numberFloatProperty;
+    }
+
+    @JsonProperty("numberFloatProperty")
+    public void setNumberFloatProperty(String numberFloatProperty) {
+        this.numberFloatProperty = numberFloatProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse numberDoubleProperty(String numberDoubleProperty) {
+        this.numberDoubleProperty = numberDoubleProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberDoubleProperty")
+    public String getNumberDoubleProperty() {
+        return numberDoubleProperty;
+    }
+
+    @JsonProperty("numberDoubleProperty")
+    public void setNumberDoubleProperty(String numberDoubleProperty) {
+        this.numberDoubleProperty = numberDoubleProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse booleanProperty(String booleanProperty) {
+        this.booleanProperty = booleanProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("booleanProperty")
+    public String getBooleanProperty() {
+        return booleanProperty;
+    }
+
+    @JsonProperty("booleanProperty")
+    public void setBooleanProperty(String booleanProperty) {
+        this.booleanProperty = booleanProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringProperty(String stringProperty) {
+        this.stringProperty = stringProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringProperty")
+    public String getStringProperty() {
+        return stringProperty;
+    }
+
+    @JsonProperty("stringProperty")
+    public void setStringProperty(String stringProperty) {
+        this.stringProperty = stringProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringByteArrayProperty(String stringByteArrayProperty) {
+        this.stringByteArrayProperty = stringByteArrayProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringByteArrayProperty")
+    public String getStringByteArrayProperty() {
+        return stringByteArrayProperty;
+    }
+
+    @JsonProperty("stringByteArrayProperty")
+    public void setStringByteArrayProperty(String stringByteArrayProperty) {
+        this.stringByteArrayProperty = stringByteArrayProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringDateProperty(String stringDateProperty) {
+        this.stringDateProperty = stringDateProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringDateProperty")
+    public String getStringDateProperty() {
+        return stringDateProperty;
+    }
+
+    @JsonProperty("stringDateProperty")
+    public void setStringDateProperty(String stringDateProperty) {
+        this.stringDateProperty = stringDateProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringDateTimeProperty(String stringDateTimeProperty) {
+        this.stringDateTimeProperty = stringDateTimeProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringDateTimeProperty")
+    public String getStringDateTimeProperty() {
+        return stringDateTimeProperty;
+    }
+
+    @JsonProperty("stringDateTimeProperty")
+    public void setStringDateTimeProperty(String stringDateTimeProperty) {
+        this.stringDateTimeProperty = stringDateTimeProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringNumberProperty(String stringNumberProperty) {
+        this.stringNumberProperty = stringNumberProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringNumberProperty")
+    public String getStringNumberProperty() {
+        return stringNumberProperty;
+    }
+
+    @JsonProperty("stringNumberProperty")
+    public void setStringNumberProperty(String stringNumberProperty) {
+        this.stringNumberProperty = stringNumberProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringUuidProperty(String stringUuidProperty) {
+        this.stringUuidProperty = stringUuidProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringUuidProperty")
+    public String getStringUuidProperty() {
+        return stringUuidProperty;
+    }
+
+    @JsonProperty("stringUuidProperty")
+    public void setStringUuidProperty(String stringUuidProperty) {
+        this.stringUuidProperty = stringUuidProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringUriProperty(String stringUriProperty) {
+        this.stringUriProperty = stringUriProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringUriProperty")
+    public String getStringUriProperty() {
+        return stringUriProperty;
+    }
+
+    @JsonProperty("stringUriProperty")
+    public void setStringUriProperty(String stringUriProperty) {
+        this.stringUriProperty = stringUriProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse arrayProperty(List<String> arrayProperty) {
+        this.arrayProperty = arrayProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayProperty")
+    public List<String> getArrayProperty() {
+        return arrayProperty;
+    }
+
+    @JsonProperty("arrayProperty")
+    public void setArrayProperty(List<String> arrayProperty) {
+        this.arrayProperty = arrayProperty;
+    }
+
+    public DataTypeResponse addArrayPropertyItem(String arrayPropertyItem) {
+        if (this.arrayProperty == null) {
+            this.arrayProperty = new ArrayList<>();
+        }
+
+        this.arrayProperty.add(arrayPropertyItem);
+        return this;
+    }
+
+    public DataTypeResponse removeArrayPropertyItem(String arrayPropertyItem) {
+        if (arrayPropertyItem != null && this.arrayProperty != null) {
+            this.arrayProperty.remove(arrayPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public DataTypeResponse arrayUniqueItemsConstraintProperty(Set<String> arrayUniqueItemsConstraintProperty) {
+        this.arrayUniqueItemsConstraintProperty = arrayUniqueItemsConstraintProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayUniqueItemsConstraintProperty")
+    public Set<String> getArrayUniqueItemsConstraintProperty() {
+        return arrayUniqueItemsConstraintProperty;
+    }
+
+    @JsonProperty("arrayUniqueItemsConstraintProperty")
+    @JsonDeserialize(as = LinkedHashSet.class)
+    public void setArrayUniqueItemsConstraintProperty(Set<String> arrayUniqueItemsConstraintProperty) {
+        this.arrayUniqueItemsConstraintProperty = arrayUniqueItemsConstraintProperty;
+    }
+
+    public DataTypeResponse addArrayUniqueItemsConstraintPropertyItem(String arrayUniqueItemsConstraintPropertyItem) {
+        if (this.arrayUniqueItemsConstraintProperty == null) {
+            this.arrayUniqueItemsConstraintProperty = new LinkedHashSet<>();
+        }
+
+        this.arrayUniqueItemsConstraintProperty.add(arrayUniqueItemsConstraintPropertyItem);
+        return this;
+    }
+
+    public DataTypeResponse removeArrayUniqueItemsConstraintPropertyItem(String arrayUniqueItemsConstraintPropertyItem) {
+        if (arrayUniqueItemsConstraintPropertyItem != null && this.arrayUniqueItemsConstraintProperty != null) {
+            this.arrayUniqueItemsConstraintProperty.remove(arrayUniqueItemsConstraintPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public DataTypeResponse objectProperty(DataSubTypeResponse objectProperty) {
+        this.objectProperty = objectProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("objectProperty")
+    public DataSubTypeResponse getObjectProperty() {
+        return objectProperty;
+    }
+
+    @JsonProperty("objectProperty")
+    public void setObjectProperty(DataSubTypeResponse objectProperty) {
+        this.objectProperty = objectProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse arrayObjectProperty(List<DataSubTypeResponse> arrayObjectProperty) {
+        this.arrayObjectProperty = arrayObjectProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayObjectProperty")
+    public List<DataSubTypeResponse> getArrayObjectProperty() {
+        return arrayObjectProperty;
+    }
+
+    @JsonProperty("arrayObjectProperty")
+    public void setArrayObjectProperty(List<DataSubTypeResponse> arrayObjectProperty) {
+        this.arrayObjectProperty = arrayObjectProperty;
+    }
+
+    public DataTypeResponse addArrayObjectPropertyItem(DataSubTypeResponse arrayObjectPropertyItem) {
+        if (this.arrayObjectProperty == null) {
+            this.arrayObjectProperty = new ArrayList<>();
+        }
+
+        this.arrayObjectProperty.add(arrayObjectPropertyItem);
+        return this;
+    }
+
+    public DataTypeResponse removeArrayObjectPropertyItem(DataSubTypeResponse arrayObjectPropertyItem) {
+        if (arrayObjectPropertyItem != null && this.arrayObjectProperty != null) {
+            this.arrayObjectProperty.remove(arrayObjectPropertyItem);
+        }
+
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DataTypeResponse dataTypeResponse = (DataTypeResponse) o;
+        return Objects.equals(this.integerProperty, dataTypeResponse.integerProperty) &&
+            Objects.equals(this.integerInt32Property, dataTypeResponse.integerInt32Property) &&
+            Objects.equals(this.integerInt64Property, dataTypeResponse.integerInt64Property) &&
+            Objects.equals(this.numberProperty, dataTypeResponse.numberProperty) &&
+            Objects.equals(this.numberFloatProperty, dataTypeResponse.numberFloatProperty) &&
+            Objects.equals(this.numberDoubleProperty, dataTypeResponse.numberDoubleProperty) &&
+            Objects.equals(this.booleanProperty, dataTypeResponse.booleanProperty) &&
+            Objects.equals(this.stringProperty, dataTypeResponse.stringProperty) &&
+            Arrays.equals(this.stringByteArrayProperty, dataTypeResponse.stringByteArrayProperty) &&
+            Objects.equals(this.stringDateProperty, dataTypeResponse.stringDateProperty) &&
+            Objects.equals(this.stringDateTimeProperty, dataTypeResponse.stringDateTimeProperty) &&
+            Objects.equals(this.stringNumberProperty, dataTypeResponse.stringNumberProperty) &&
+            Objects.equals(this.stringUuidProperty, dataTypeResponse.stringUuidProperty) &&
+            Objects.equals(this.stringUriProperty, dataTypeResponse.stringUriProperty) &&
+            Objects.equals(this.arrayProperty, dataTypeResponse.arrayProperty) &&
+            Objects.equals(this.arrayUniqueItemsConstraintProperty, dataTypeResponse.arrayUniqueItemsConstraintProperty) &&
+            Objects.equals(this.objectProperty, dataTypeResponse.objectProperty) &&
+            Objects.equals(this.arrayObjectProperty, dataTypeResponse.arrayObjectProperty);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(integerProperty, integerInt32Property, integerInt64Property, numberProperty, numberFloatProperty, numberDoubleProperty, booleanProperty, stringProperty, Arrays.hashCode(stringByteArrayProperty), stringDateProperty, stringDateTimeProperty, stringNumberProperty, stringUuidProperty, stringUriProperty, arrayProperty, arrayUniqueItemsConstraintProperty, objectProperty, arrayObjectProperty);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class DataTypeResponse {\n");
+        
+        sb.append("    integerProperty: ").append(toIndentedString(integerProperty)).append("\n");
+        sb.append("    integerInt32Property: ").append(toIndentedString(integerInt32Property)).append("\n");
+        sb.append("    integerInt64Property: ").append(toIndentedString(integerInt64Property)).append("\n");
+        sb.append("    numberProperty: ").append(toIndentedString(numberProperty)).append("\n");
+        sb.append("    numberFloatProperty: ").append(toIndentedString(numberFloatProperty)).append("\n");
+        sb.append("    numberDoubleProperty: ").append(toIndentedString(numberDoubleProperty)).append("\n");
+        sb.append("    booleanProperty: ").append(toIndentedString(booleanProperty)).append("\n");
+        sb.append("    stringProperty: ").append(toIndentedString(stringProperty)).append("\n");
+        sb.append("    stringByteArrayProperty: ").append(toIndentedString(stringByteArrayProperty)).append("\n");
+        sb.append("    stringDateProperty: ").append(toIndentedString(stringDateProperty)).append("\n");
+        sb.append("    stringDateTimeProperty: ").append(toIndentedString(stringDateTimeProperty)).append("\n");
+        sb.append("    stringNumberProperty: ").append(toIndentedString(stringNumberProperty)).append("\n");
+        sb.append("    stringUuidProperty: ").append(toIndentedString(stringUuidProperty)).append("\n");
+        sb.append("    stringUriProperty: ").append(toIndentedString(stringUriProperty)).append("\n");
+        sb.append("    arrayProperty: ").append(toIndentedString(arrayProperty)).append("\n");
+        sb.append("    arrayUniqueItemsConstraintProperty: ").append(toIndentedString(arrayUniqueItemsConstraintProperty)).append("\n");
+        sb.append("    objectProperty: ").append(toIndentedString(objectProperty)).append("\n");
+        sb.append("    arrayObjectProperty: ").append(toIndentedString(arrayObjectProperty)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/all_data_types.yaml
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/all_data_types.yaml
@@ -1,0 +1,165 @@
+---
+openapi: 3.0.3
+info:
+  title: OpenAPI API Sample
+  version: 0.0.1
+servers:
+- url: http://localhost:8080
+  description: OpenAPI API Sample description
+paths:
+  /data-types:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DataTypeResponse'
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataTypeRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataTypeResponse'
+components:
+  schemas:
+    DataSubTypeRequest:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    DataSubTypeResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    DataTypeRequest:
+      type: object
+      properties:
+        integerProperty:
+          type: integer
+        integerInt32Property:
+          format: int32
+          type: integer
+        integerInt64Property:
+          format: int64
+          type: integer
+        numberProperty:
+          type: number
+        numberFloatProperty:
+          format: float
+          type: number
+        numberDoubleProperty:
+          format: double
+          type: number
+        booleanProperty:
+          type: boolean
+        stringProperty:
+          type: string
+        stringByteArrayProperty:
+          format: byte
+          type: string
+        stringDateProperty:
+          format: date
+          type: string
+          example: 2022-03-10
+        stringDateTimeProperty:
+          format: date-time
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        stringNumberProperty:
+          format: number
+          type: string
+        stringUuidProperty:
+          format: uuid
+          type: string
+        stringUriProperty:
+          format: uri
+          type: string
+        arrayProperty:
+          type: array
+          items:
+            type: string
+        arrayUniqueItemsConstraintProperty:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        objectProperty:
+          $ref: '#/components/schemas/DataSubTypeRequest'
+        arrayObjectProperty:
+          type: array
+          items:
+            $ref: '#/components/schemas/DataSubTypeRequest'
+    DataTypeResponse:
+      type: object
+      properties:
+        integerProperty:
+          type: integer
+        integerInt32Property:
+          format: int32
+          type: integer
+        integerInt64Property:
+          format: int64
+          type: integer
+        numberProperty:
+          type: number
+        numberFloatProperty:
+          format: float
+          type: number
+        numberDoubleProperty:
+          format: double
+          type: number
+        booleanProperty:
+          type: boolean
+        stringProperty:
+          type: string
+        stringByteArrayProperty:
+          format: byte
+          type: string
+        stringDateProperty:
+          format: date
+          type: string
+          example: 2022-03-10
+        stringDateTimeProperty:
+          format: date-time
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        stringNumberProperty:
+          format: number
+          type: string
+        stringUuidProperty:
+          format: uuid
+          type: string
+        stringUriProperty:
+          format: uri
+          type: string
+        arrayProperty:
+          type: array
+          items:
+            type: string
+        arrayUniqueItemsConstraintProperty:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        objectProperty:
+          $ref: '#/components/schemas/DataSubTypeResponse'
+        arrayObjectProperty:
+          type: array
+          items:
+            $ref: '#/components/schemas/DataSubTypeResponse'

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/all_data_types_included_unofficial_supported_types.yaml
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/all_data_types_included_unofficial_supported_types.yaml
@@ -1,0 +1,261 @@
+---
+openapi: 3.0.3
+info:
+  title: OpenAPI API Sample
+  version: 0.0.1
+servers:
+- url: http://localhost:8080
+  description: OpenAPI API Sample description
+paths:
+  /data-types:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DataTypeResponse'
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataTypeRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataTypeResponse'
+components:
+  schemas:
+    DataSubTypeRequest:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    DataSubTypeResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    DataTypeRequest:
+      type: object
+      properties:
+        integerProperty:
+          type: integer
+        integerInt32Property:
+          format: int32
+          type: integer
+        integerInt64Property:
+          format: int64
+          type: integer
+        numberProperty:
+          type: number
+        numberFloatProperty:
+          format: float
+          type: number
+        numberDoubleProperty:
+          format: double
+          type: number
+        booleanProperty:
+          type: boolean
+        stringProperty:
+          type: string
+        stringByteArrayProperty:
+          format: byte
+          type: string
+        stringDateProperty:
+          format: date
+          type: string
+          example: 2022-03-10
+        stringTimeProperty:
+          format: time
+          type: string
+        stringDateTimeProperty:
+          format: date-time
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        stringDurationProperty:
+          format: duration
+          type: string
+        stringPasswordProperty:
+          format: password
+          type: string
+        stringNumberProperty:
+          format: number
+          type: string
+        stringEmailProperty:
+          format: email
+          type: string
+        stringIdnEmailProperty:
+          format: idn-email
+          type: string
+        stringHostnameProperty:
+          format: hostname
+          type: string
+        stringIdnHostnameProperty:
+          format: idn-hostname
+          type: string
+        stringIpv4Property:
+          format: ipv4
+          type: string
+        stringIpv6Property:
+          format: ipv6
+          type: string
+        stringUuidProperty:
+          format: uuid
+          type: string
+        stringUriProperty:
+          format: uri
+          type: string
+        stringUriReferenceProperty:
+          format: uri-reference
+          type: string
+        stringUriTemplateProperty:
+          format: uri-template
+          type: string
+        stringIriProperty:
+          format: iri
+          type: string
+        stringIriReferenceProperty:
+          format: iri-reference
+          type: string
+        stringJsonPointerProperty:
+          format: json-pointer
+          type: string
+        stringRelativeJsonPointerProperty:
+          format: relative-json-pointer
+          type: string
+        stringRegexProperty:
+          format: regex
+          type: string
+        arrayProperty:
+          type: array
+          items:
+            type: string
+        arrayUniqueItemsConstraintProperty:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        objectProperty:
+          $ref: '#/components/schemas/DataSubTypeRequest'
+        arrayObjectProperty:
+          type: array
+          items:
+            $ref: '#/components/schemas/DataSubTypeRequest'
+    DataTypeResponse:
+      type: object
+      properties:
+        integerProperty:
+          type: integer
+        integerInt32Property:
+          format: int32
+          type: integer
+        integerInt64Property:
+          format: int64
+          type: integer
+        numberProperty:
+          type: number
+        numberFloatProperty:
+          format: float
+          type: number
+        numberDoubleProperty:
+          format: double
+          type: number
+        booleanProperty:
+          type: boolean
+        stringProperty:
+          type: string
+        stringByteArrayProperty:
+          format: byte
+          type: string
+        stringDateProperty:
+          format: date
+          type: string
+          example: 2022-03-10
+        stringTimeProperty:
+          format: time
+          type: string
+        stringDateTimeProperty:
+          format: date-time
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        stringDurationProperty:
+          format: duration
+          type: string
+        stringPasswordProperty:
+          format: password
+          type: string
+        stringNumberProperty:
+          format: number
+          type: string
+        stringEmailProperty:
+          format: email
+          type: string
+        stringIdnEmailProperty:
+          format: idn-email
+          type: string
+        stringHostnameProperty:
+          format: hostname
+          type: string
+        stringIdnHostnameProperty:
+          format: idn-hostname
+          type: string
+        stringIpv4Property:
+          format: ipv4
+          type: string
+        stringIpv6Property:
+          format: ipv6
+          type: string
+        stringUuidProperty:
+          format: uuid
+          type: string
+        stringUriProperty:
+          format: uri
+          type: string
+        stringUriReferenceProperty:
+          format: uri-reference
+          type: string
+        stringUriTemplateProperty:
+          format: uri-template
+          type: string
+        stringIriProperty:
+          format: iri
+          type: string
+        stringIriReferenceProperty:
+          format: iri-reference
+          type: string
+        stringJsonPointerProperty:
+          format: json-pointer
+          type: string
+        stringRelativeJsonPointerProperty:
+          format: relative-json-pointer
+          type: string
+        stringRegexProperty:
+          format: regex
+          type: string
+        arrayProperty:
+          type: array
+          items:
+            type: string
+        arrayUniqueItemsConstraintProperty:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        objectProperty:
+          $ref: '#/components/schemas/DataSubTypeResponse'
+        arrayObjectProperty:
+          type: array
+          items:
+            $ref: '#/components/schemas/DataSubTypeResponse'

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/all_data_types_with_binary_request.yaml
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/all_data_types_with_binary_request.yaml
@@ -1,0 +1,168 @@
+---
+openapi: 3.0.3
+info:
+  title: OpenAPI API Sample
+  version: 0.0.1
+servers:
+- url: http://localhost:8080
+  description: OpenAPI API Sample description
+paths:
+  /data-types:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DataTypeResponse'
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataTypeRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataTypeResponse'
+components:
+  schemas:
+    DataSubTypeRequest:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    DataSubTypeResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    DataTypeRequest:
+      type: object
+      properties:
+        integerProperty:
+          type: integer
+        integerInt32Property:
+          format: int32
+          type: integer
+        integerInt64Property:
+          format: int64
+          type: integer
+        numberProperty:
+          type: number
+        numberFloatProperty:
+          format: float
+          type: number
+        numberDoubleProperty:
+          format: double
+          type: number
+        booleanProperty:
+          type: boolean
+        stringProperty:
+          type: string
+        stringByteArrayProperty:
+          format: byte
+          type: string
+        stringBinaryProperty:
+          format: binary
+          type: string
+        stringDateProperty:
+          format: date
+          type: string
+          example: 2022-03-10
+        stringDateTimeProperty:
+          format: date-time
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        stringNumberProperty:
+          format: number
+          type: string
+        stringUuidProperty:
+          format: uuid
+          type: string
+        stringUriProperty:
+          format: uri
+          type: string
+        arrayProperty:
+          type: array
+          items:
+            type: string
+        arrayUniqueItemsConstraintProperty:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        objectProperty:
+          $ref: '#/components/schemas/DataSubTypeRequest'
+        arrayObjectProperty:
+          type: array
+          items:
+            $ref: '#/components/schemas/DataSubTypeRequest'
+    DataTypeResponse:
+      type: object
+      properties:
+        integerProperty:
+          type: integer
+        integerInt32Property:
+          format: int32
+          type: integer
+        integerInt64Property:
+          format: int64
+          type: integer
+        numberProperty:
+          type: number
+        numberFloatProperty:
+          format: float
+          type: number
+        numberDoubleProperty:
+          format: double
+          type: number
+        booleanProperty:
+          type: boolean
+        stringProperty:
+          type: string
+        stringByteArrayProperty:
+          format: byte
+          type: string
+        stringDateProperty:
+          format: date
+          type: string
+          example: 2022-03-10
+        stringDateTimeProperty:
+          format: date-time
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        stringNumberProperty:
+          format: number
+          type: string
+        stringUuidProperty:
+          format: uuid
+          type: string
+        stringUriProperty:
+          format: uri
+          type: string
+        arrayProperty:
+          type: array
+          items:
+            type: string
+        arrayUniqueItemsConstraintProperty:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        objectProperty:
+          $ref: '#/components/schemas/DataSubTypeResponse'
+        arrayObjectProperty:
+          type: array
+          items:
+            $ref: '#/components/schemas/DataSubTypeResponse'

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/all_data_types_with_binary_response.yaml
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/all_data_types_with_binary_response.yaml
@@ -1,0 +1,170 @@
+---
+openapi: 3.0.3
+info:
+  title: OpenAPI API Sample
+  version: 0.0.1
+servers:
+- url: http://localhost:8080
+  description: OpenAPI API Sample description
+paths:
+  /data-types:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DataTypeResponse'
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataTypeRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataTypeResponse'
+components:
+  schemas:
+    DataSubTypeRequest:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    DataSubTypeResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    DataTypeRequest:
+      type: object
+      properties:
+        integerProperty:
+          type: integer
+        integerInt32Property:
+          format: int32
+          type: integer
+        integerInt64Property:
+          format: int64
+          type: integer
+        numberProperty:
+          type: number
+        numberFloatProperty:
+          format: float
+          type: number
+        numberDoubleProperty:
+          format: double
+          type: number
+        booleanProperty:
+          type: boolean
+        stringProperty:
+          type: string
+        stringByteArrayProperty:
+          format: byte
+          type: string
+        stringDateProperty:
+          format: date
+          type: string
+          example: 2022-03-10
+        stringDateTimeProperty:
+          format: date-time
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        stringNumberProperty:
+          format: number
+          type: string
+        stringUuidProperty:
+          format: uuid
+          pattern: "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+          type: string
+        stringUriProperty:
+          format: uri
+          type: string
+        arrayProperty:
+          type: array
+          items:
+            type: string
+        arrayUniqueItemsConstraintProperty:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        objectProperty:
+          $ref: '#/components/schemas/DataSubTypeRequest'
+        arrayObjectProperty:
+          type: array
+          items:
+            $ref: '#/components/schemas/DataSubTypeRequest'
+    DataTypeResponse:
+      type: object
+      properties:
+        integerProperty:
+          type: integer
+        integerInt32Property:
+          format: int32
+          type: integer
+        integerInt64Property:
+          format: int64
+          type: integer
+        numberProperty:
+          type: number
+        numberFloatProperty:
+          format: float
+          type: number
+        numberDoubleProperty:
+          format: double
+          type: number
+        booleanProperty:
+          type: boolean
+        stringProperty:
+          type: string
+        stringByteArrayProperty:
+          format: byte
+          type: string
+        stringBinaryProperty:
+          format: binary
+          type: string
+        stringDateProperty:
+          format: date
+          type: string
+          example: 2022-03-10
+        stringDateTimeProperty:
+          format: date-time
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        stringNumberProperty:
+          format: number
+          type: string
+        stringUuidProperty:
+          format: uuid
+          pattern: "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+          type: string
+        stringUriProperty:
+          format: uri
+          type: string
+        arrayProperty:
+          type: array
+          items:
+            type: string
+        arrayUniqueItemsConstraintProperty:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        objectProperty:
+          $ref: '#/components/schemas/DataSubTypeResponse'
+        arrayObjectProperty:
+          type: array
+          items:
+            $ref: '#/components/schemas/DataSubTypeResponse'

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/all_data_types_with_multipart_binary_request.yaml
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/all_data_types_with_multipart_binary_request.yaml
@@ -1,0 +1,170 @@
+---
+openapi: 3.0.3
+info:
+  title: OpenAPI API Sample
+  version: 0.0.1
+servers:
+- url: http://localhost:8080
+  description: OpenAPI API Sample description
+paths:
+  /data-types:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DataTypeResponse'
+    post:
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/DataTypeRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataTypeResponse'
+components:
+  schemas:
+    DataSubTypeRequest:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    DataSubTypeResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    DataTypeRequest:
+      type: object
+      properties:
+        integerProperty:
+          type: integer
+        integerInt32Property:
+          format: int32
+          type: integer
+        integerInt64Property:
+          format: int64
+          type: integer
+        numberProperty:
+          type: number
+        numberFloatProperty:
+          format: float
+          type: number
+        numberDoubleProperty:
+          format: double
+          type: number
+        booleanProperty:
+          type: boolean
+        stringProperty:
+          type: string
+        stringByteArrayProperty:
+          format: byte
+          type: string
+        stringBinaryProperty:
+          format: binary
+          type: string
+        stringDateProperty:
+          format: date
+          type: string
+          example: 2022-03-10
+        stringDateTimeProperty:
+          format: date-time
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        stringNumberProperty:
+          format: number
+          type: string
+        stringUuidProperty:
+          format: uuid
+          pattern: "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+          type: string
+        stringUriProperty:
+          format: uri
+          type: string
+        arrayProperty:
+          type: array
+          items:
+            type: string
+        arrayUniqueItemsConstraintProperty:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        objectProperty:
+          $ref: '#/components/schemas/DataSubTypeRequest'
+        arrayObjectProperty:
+          type: array
+          items:
+            $ref: '#/components/schemas/DataSubTypeRequest'
+    DataTypeResponse:
+      type: object
+      properties:
+        integerProperty:
+          type: integer
+        integerInt32Property:
+          format: int32
+          type: integer
+        integerInt64Property:
+          format: int64
+          type: integer
+        numberProperty:
+          type: number
+        numberFloatProperty:
+          format: float
+          type: number
+        numberDoubleProperty:
+          format: double
+          type: number
+        booleanProperty:
+          type: boolean
+        stringProperty:
+          type: string
+        stringByteArrayProperty:
+          format: byte
+          type: string
+        stringDateProperty:
+          format: date
+          type: string
+          example: 2022-03-10
+        stringDateTimeProperty:
+          format: date-time
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        stringNumberProperty:
+          format: number
+          type: string
+        stringUuidProperty:
+          format: uuid
+          pattern: "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+          type: string
+        stringUriProperty:
+          format: uri
+          type: string
+        arrayProperty:
+          type: array
+          items:
+            type: string
+        arrayUniqueItemsConstraintProperty:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        objectProperty:
+          $ref: '#/components/schemas/DataSubTypeResponse'
+        arrayObjectProperty:
+          type: array
+          items:
+            $ref: '#/components/schemas/DataSubTypeResponse'

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/all_data_types_with_multipart_binary_response.yaml
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/all_data_types_with_multipart_binary_response.yaml
@@ -1,0 +1,170 @@
+---
+openapi: 3.0.3
+info:
+  title: OpenAPI API Sample
+  version: 0.0.1
+servers:
+- url: http://localhost:8080
+  description: OpenAPI API Sample description
+paths:
+  /data-types:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            multipart/form-data:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DataTypeResponse'
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataTypeRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            multipart/form-data:
+              schema:
+                $ref: '#/components/schemas/DataTypeResponse'
+components:
+  schemas:
+    DataSubTypeRequest:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    DataSubTypeResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    DataTypeRequest:
+      type: object
+      properties:
+        integerProperty:
+          type: integer
+        integerInt32Property:
+          format: int32
+          type: integer
+        integerInt64Property:
+          format: int64
+          type: integer
+        numberProperty:
+          type: number
+        numberFloatProperty:
+          format: float
+          type: number
+        numberDoubleProperty:
+          format: double
+          type: number
+        booleanProperty:
+          type: boolean
+        stringProperty:
+          type: string
+        stringByteArrayProperty:
+          format: byte
+          type: string
+        stringDateProperty:
+          format: date
+          type: string
+          example: 2022-03-10
+        stringDateTimeProperty:
+          format: date-time
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        stringNumberProperty:
+          format: number
+          type: string
+        stringUuidProperty:
+          format: uuid
+          pattern: "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+          type: string
+        stringUriProperty:
+          format: uri
+          type: string
+        arrayProperty:
+          type: array
+          items:
+            type: string
+        arrayUniqueItemsConstraintProperty:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        objectProperty:
+          $ref: '#/components/schemas/DataSubTypeRequest'
+        arrayObjectProperty:
+          type: array
+          items:
+            $ref: '#/components/schemas/DataSubTypeRequest'
+    DataTypeResponse:
+      type: object
+      properties:
+        integerProperty:
+          type: integer
+        integerInt32Property:
+          format: int32
+          type: integer
+        integerInt64Property:
+          format: int64
+          type: integer
+        numberProperty:
+          type: number
+        numberFloatProperty:
+          format: float
+          type: number
+        numberDoubleProperty:
+          format: double
+          type: number
+        booleanProperty:
+          type: boolean
+        stringProperty:
+          type: string
+        stringByteArrayProperty:
+          format: byte
+          type: string
+        stringBinaryProperty:
+          format: binary
+          type: string
+        stringDateProperty:
+          format: date
+          type: string
+          example: 2022-03-10
+        stringDateTimeProperty:
+          format: date-time
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        stringNumberProperty:
+          format: number
+          type: string
+        stringUuidProperty:
+          format: uuid
+          pattern: "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+          type: string
+        stringUriProperty:
+          format: uri
+          type: string
+        arrayProperty:
+          type: array
+          items:
+            type: string
+        arrayUniqueItemsConstraintProperty:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        objectProperty:
+          $ref: '#/components/schemas/DataSubTypeResponse'
+        arrayObjectProperty:
+          type: array
+          items:
+            $ref: '#/components/schemas/DataSubTypeResponse'

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/file_download.yaml
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/file_download.yaml
@@ -1,0 +1,19 @@
+---
+openapi: 3.0.3
+info:
+  title: OpenAPI API Sample
+  version: 0.0.1
+servers:
+- url: http://localhost:8080
+  description: OpenAPI API Sample description
+paths:
+  /data-types:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/includeMultipartBinaryFormatRequest/expected/src/gen/java/org/openapitools/api/DataTypesApi.java
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/includeMultipartBinaryFormatRequest/expected/src/gen/java/org/openapitools/api/DataTypesApi.java
@@ -1,0 +1,47 @@
+package org.openapitools.api;
+
+import java.math.BigDecimal;
+import org.openapitools.model.DataSubTypeRequest;
+import org.openapitools.model.DataTypeResponse;
+import nablarch.fw.jaxrs.EntityResponse;
+import nablarch.fw.ExecutionContext;
+import java.io.File;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.net.URI;
+import java.util.UUID;
+
+import jakarta.ws.rs.*;
+
+@Path("/data-types")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:43:46.796582783+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface DataTypesApi {
+    /**
+     * GET 
+     *
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return OK
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<DataTypeResponse>> dataTypesGet(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * POST 
+     *
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return OK
+     */
+    @POST
+    @Consumes({ "multipart/form-data" })
+    @Produces({ "application/json" })
+    EntityResponse<DataTypeResponse> dataTypesPost(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/includeMultipartBinaryFormatRequest/expected/src/gen/java/org/openapitools/model/DataSubTypeRequest.java
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/includeMultipartBinaryFormatRequest/expected/src/gen/java/org/openapitools/model/DataSubTypeRequest.java
@@ -1,0 +1,97 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+
+@JsonTypeName("DataSubTypeRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:43:46.796582783+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class DataSubTypeRequest   {
+  private String id;
+  private String name;
+
+    /**
+     */
+    public DataSubTypeRequest id(String id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     */
+    public DataSubTypeRequest name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DataSubTypeRequest dataSubTypeRequest = (DataSubTypeRequest) o;
+        return Objects.equals(this.id, dataSubTypeRequest.id) &&
+            Objects.equals(this.name, dataSubTypeRequest.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class DataSubTypeRequest {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/includeMultipartBinaryFormatRequest/expected/src/gen/java/org/openapitools/model/DataSubTypeResponse.java
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/includeMultipartBinaryFormatRequest/expected/src/gen/java/org/openapitools/model/DataSubTypeResponse.java
@@ -1,0 +1,97 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+
+@JsonTypeName("DataSubTypeResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:43:46.796582783+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class DataSubTypeResponse   {
+  private String id;
+  private String name;
+
+    /**
+     */
+    public DataSubTypeResponse id(String id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     */
+    public DataSubTypeResponse name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DataSubTypeResponse dataSubTypeResponse = (DataSubTypeResponse) o;
+        return Objects.equals(this.id, dataSubTypeResponse.id) &&
+            Objects.equals(this.name, dataSubTypeResponse.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class DataSubTypeResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/includeMultipartBinaryFormatRequest/expected/src/gen/java/org/openapitools/model/DataTypeResponse.java
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/includeMultipartBinaryFormatRequest/expected/src/gen/java/org/openapitools/model/DataTypeResponse.java
@@ -1,0 +1,493 @@
+package org.openapitools.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.openapitools.model.DataSubTypeResponse;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+
+@JsonTypeName("DataTypeResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:43:46.796582783+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class DataTypeResponse   {
+  private Integer integerProperty;
+  private Integer integerInt32Property;
+  private Long integerInt64Property;
+  private BigDecimal numberProperty;
+  private Float numberFloatProperty;
+  private Double numberDoubleProperty;
+  private Boolean booleanProperty;
+  private String stringProperty;
+  private byte[] stringByteArrayProperty;
+  private LocalDate stringDateProperty;
+  private OffsetDateTime stringDateTimeProperty;
+  private BigDecimal stringNumberProperty;
+  private UUID stringUuidProperty;
+  private URI stringUriProperty;
+  private List<String> arrayProperty = new ArrayList<>();
+  private Set<String> arrayUniqueItemsConstraintProperty = new LinkedHashSet<>();
+  private DataSubTypeResponse objectProperty;
+  private List<DataSubTypeResponse> arrayObjectProperty = new ArrayList<>();
+
+    /**
+     */
+    public DataTypeResponse integerProperty(Integer integerProperty) {
+        this.integerProperty = integerProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerProperty")
+    public Integer getIntegerProperty() {
+        return integerProperty;
+    }
+
+    @JsonProperty("integerProperty")
+    public void setIntegerProperty(Integer integerProperty) {
+        this.integerProperty = integerProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse integerInt32Property(Integer integerInt32Property) {
+        this.integerInt32Property = integerInt32Property;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt32Property")
+    public Integer getIntegerInt32Property() {
+        return integerInt32Property;
+    }
+
+    @JsonProperty("integerInt32Property")
+    public void setIntegerInt32Property(Integer integerInt32Property) {
+        this.integerInt32Property = integerInt32Property;
+    }
+
+    /**
+     */
+    public DataTypeResponse integerInt64Property(Long integerInt64Property) {
+        this.integerInt64Property = integerInt64Property;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt64Property")
+    public Long getIntegerInt64Property() {
+        return integerInt64Property;
+    }
+
+    @JsonProperty("integerInt64Property")
+    public void setIntegerInt64Property(Long integerInt64Property) {
+        this.integerInt64Property = integerInt64Property;
+    }
+
+    /**
+     */
+    public DataTypeResponse numberProperty(BigDecimal numberProperty) {
+        this.numberProperty = numberProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberProperty")
+    public BigDecimal getNumberProperty() {
+        return numberProperty;
+    }
+
+    @JsonProperty("numberProperty")
+    public void setNumberProperty(BigDecimal numberProperty) {
+        this.numberProperty = numberProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse numberFloatProperty(Float numberFloatProperty) {
+        this.numberFloatProperty = numberFloatProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberFloatProperty")
+    public Float getNumberFloatProperty() {
+        return numberFloatProperty;
+    }
+
+    @JsonProperty("numberFloatProperty")
+    public void setNumberFloatProperty(Float numberFloatProperty) {
+        this.numberFloatProperty = numberFloatProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse numberDoubleProperty(Double numberDoubleProperty) {
+        this.numberDoubleProperty = numberDoubleProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberDoubleProperty")
+    public Double getNumberDoubleProperty() {
+        return numberDoubleProperty;
+    }
+
+    @JsonProperty("numberDoubleProperty")
+    public void setNumberDoubleProperty(Double numberDoubleProperty) {
+        this.numberDoubleProperty = numberDoubleProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse booleanProperty(Boolean booleanProperty) {
+        this.booleanProperty = booleanProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("booleanProperty")
+    public Boolean getBooleanProperty() {
+        return booleanProperty;
+    }
+
+    @JsonProperty("booleanProperty")
+    public void setBooleanProperty(Boolean booleanProperty) {
+        this.booleanProperty = booleanProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringProperty(String stringProperty) {
+        this.stringProperty = stringProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringProperty")
+    public String getStringProperty() {
+        return stringProperty;
+    }
+
+    @JsonProperty("stringProperty")
+    public void setStringProperty(String stringProperty) {
+        this.stringProperty = stringProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringByteArrayProperty(byte[] stringByteArrayProperty) {
+        this.stringByteArrayProperty = stringByteArrayProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringByteArrayProperty")
+    public byte[] getStringByteArrayProperty() {
+        return stringByteArrayProperty;
+    }
+
+    @JsonProperty("stringByteArrayProperty")
+    public void setStringByteArrayProperty(byte[] stringByteArrayProperty) {
+        this.stringByteArrayProperty = stringByteArrayProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringDateProperty(LocalDate stringDateProperty) {
+        this.stringDateProperty = stringDateProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringDateProperty")
+    public LocalDate getStringDateProperty() {
+        return stringDateProperty;
+    }
+
+    @JsonProperty("stringDateProperty")
+    public void setStringDateProperty(LocalDate stringDateProperty) {
+        this.stringDateProperty = stringDateProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringDateTimeProperty(OffsetDateTime stringDateTimeProperty) {
+        this.stringDateTimeProperty = stringDateTimeProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringDateTimeProperty")
+    public OffsetDateTime getStringDateTimeProperty() {
+        return stringDateTimeProperty;
+    }
+
+    @JsonProperty("stringDateTimeProperty")
+    public void setStringDateTimeProperty(OffsetDateTime stringDateTimeProperty) {
+        this.stringDateTimeProperty = stringDateTimeProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringNumberProperty(BigDecimal stringNumberProperty) {
+        this.stringNumberProperty = stringNumberProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringNumberProperty")
+    public BigDecimal getStringNumberProperty() {
+        return stringNumberProperty;
+    }
+
+    @JsonProperty("stringNumberProperty")
+    public void setStringNumberProperty(BigDecimal stringNumberProperty) {
+        this.stringNumberProperty = stringNumberProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringUuidProperty(UUID stringUuidProperty) {
+        this.stringUuidProperty = stringUuidProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringUuidProperty")
+    public UUID getStringUuidProperty() {
+        return stringUuidProperty;
+    }
+
+    @JsonProperty("stringUuidProperty")
+    public void setStringUuidProperty(UUID stringUuidProperty) {
+        this.stringUuidProperty = stringUuidProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse stringUriProperty(URI stringUriProperty) {
+        this.stringUriProperty = stringUriProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringUriProperty")
+    public URI getStringUriProperty() {
+        return stringUriProperty;
+    }
+
+    @JsonProperty("stringUriProperty")
+    public void setStringUriProperty(URI stringUriProperty) {
+        this.stringUriProperty = stringUriProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse arrayProperty(List<String> arrayProperty) {
+        this.arrayProperty = arrayProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayProperty")
+    public List<String> getArrayProperty() {
+        return arrayProperty;
+    }
+
+    @JsonProperty("arrayProperty")
+    public void setArrayProperty(List<String> arrayProperty) {
+        this.arrayProperty = arrayProperty;
+    }
+
+    public DataTypeResponse addArrayPropertyItem(String arrayPropertyItem) {
+        if (this.arrayProperty == null) {
+            this.arrayProperty = new ArrayList<>();
+        }
+
+        this.arrayProperty.add(arrayPropertyItem);
+        return this;
+    }
+
+    public DataTypeResponse removeArrayPropertyItem(String arrayPropertyItem) {
+        if (arrayPropertyItem != null && this.arrayProperty != null) {
+            this.arrayProperty.remove(arrayPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public DataTypeResponse arrayUniqueItemsConstraintProperty(Set<String> arrayUniqueItemsConstraintProperty) {
+        this.arrayUniqueItemsConstraintProperty = arrayUniqueItemsConstraintProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayUniqueItemsConstraintProperty")
+    public Set<String> getArrayUniqueItemsConstraintProperty() {
+        return arrayUniqueItemsConstraintProperty;
+    }
+
+    @JsonProperty("arrayUniqueItemsConstraintProperty")
+    @JsonDeserialize(as = LinkedHashSet.class)
+    public void setArrayUniqueItemsConstraintProperty(Set<String> arrayUniqueItemsConstraintProperty) {
+        this.arrayUniqueItemsConstraintProperty = arrayUniqueItemsConstraintProperty;
+    }
+
+    public DataTypeResponse addArrayUniqueItemsConstraintPropertyItem(String arrayUniqueItemsConstraintPropertyItem) {
+        if (this.arrayUniqueItemsConstraintProperty == null) {
+            this.arrayUniqueItemsConstraintProperty = new LinkedHashSet<>();
+        }
+
+        this.arrayUniqueItemsConstraintProperty.add(arrayUniqueItemsConstraintPropertyItem);
+        return this;
+    }
+
+    public DataTypeResponse removeArrayUniqueItemsConstraintPropertyItem(String arrayUniqueItemsConstraintPropertyItem) {
+        if (arrayUniqueItemsConstraintPropertyItem != null && this.arrayUniqueItemsConstraintProperty != null) {
+            this.arrayUniqueItemsConstraintProperty.remove(arrayUniqueItemsConstraintPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public DataTypeResponse objectProperty(DataSubTypeResponse objectProperty) {
+        this.objectProperty = objectProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("objectProperty")
+    public DataSubTypeResponse getObjectProperty() {
+        return objectProperty;
+    }
+
+    @JsonProperty("objectProperty")
+    public void setObjectProperty(DataSubTypeResponse objectProperty) {
+        this.objectProperty = objectProperty;
+    }
+
+    /**
+     */
+    public DataTypeResponse arrayObjectProperty(List<DataSubTypeResponse> arrayObjectProperty) {
+        this.arrayObjectProperty = arrayObjectProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayObjectProperty")
+    public List<DataSubTypeResponse> getArrayObjectProperty() {
+        return arrayObjectProperty;
+    }
+
+    @JsonProperty("arrayObjectProperty")
+    public void setArrayObjectProperty(List<DataSubTypeResponse> arrayObjectProperty) {
+        this.arrayObjectProperty = arrayObjectProperty;
+    }
+
+    public DataTypeResponse addArrayObjectPropertyItem(DataSubTypeResponse arrayObjectPropertyItem) {
+        if (this.arrayObjectProperty == null) {
+            this.arrayObjectProperty = new ArrayList<>();
+        }
+
+        this.arrayObjectProperty.add(arrayObjectPropertyItem);
+        return this;
+    }
+
+    public DataTypeResponse removeArrayObjectPropertyItem(DataSubTypeResponse arrayObjectPropertyItem) {
+        if (arrayObjectPropertyItem != null && this.arrayObjectProperty != null) {
+            this.arrayObjectProperty.remove(arrayObjectPropertyItem);
+        }
+
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DataTypeResponse dataTypeResponse = (DataTypeResponse) o;
+        return Objects.equals(this.integerProperty, dataTypeResponse.integerProperty) &&
+            Objects.equals(this.integerInt32Property, dataTypeResponse.integerInt32Property) &&
+            Objects.equals(this.integerInt64Property, dataTypeResponse.integerInt64Property) &&
+            Objects.equals(this.numberProperty, dataTypeResponse.numberProperty) &&
+            Objects.equals(this.numberFloatProperty, dataTypeResponse.numberFloatProperty) &&
+            Objects.equals(this.numberDoubleProperty, dataTypeResponse.numberDoubleProperty) &&
+            Objects.equals(this.booleanProperty, dataTypeResponse.booleanProperty) &&
+            Objects.equals(this.stringProperty, dataTypeResponse.stringProperty) &&
+            Arrays.equals(this.stringByteArrayProperty, dataTypeResponse.stringByteArrayProperty) &&
+            Objects.equals(this.stringDateProperty, dataTypeResponse.stringDateProperty) &&
+            Objects.equals(this.stringDateTimeProperty, dataTypeResponse.stringDateTimeProperty) &&
+            Objects.equals(this.stringNumberProperty, dataTypeResponse.stringNumberProperty) &&
+            Objects.equals(this.stringUuidProperty, dataTypeResponse.stringUuidProperty) &&
+            Objects.equals(this.stringUriProperty, dataTypeResponse.stringUriProperty) &&
+            Objects.equals(this.arrayProperty, dataTypeResponse.arrayProperty) &&
+            Objects.equals(this.arrayUniqueItemsConstraintProperty, dataTypeResponse.arrayUniqueItemsConstraintProperty) &&
+            Objects.equals(this.objectProperty, dataTypeResponse.objectProperty) &&
+            Objects.equals(this.arrayObjectProperty, dataTypeResponse.arrayObjectProperty);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(integerProperty, integerInt32Property, integerInt64Property, numberProperty, numberFloatProperty, numberDoubleProperty, booleanProperty, stringProperty, Arrays.hashCode(stringByteArrayProperty), stringDateProperty, stringDateTimeProperty, stringNumberProperty, stringUuidProperty, stringUriProperty, arrayProperty, arrayUniqueItemsConstraintProperty, objectProperty, arrayObjectProperty);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class DataTypeResponse {\n");
+        
+        sb.append("    integerProperty: ").append(toIndentedString(integerProperty)).append("\n");
+        sb.append("    integerInt32Property: ").append(toIndentedString(integerInt32Property)).append("\n");
+        sb.append("    integerInt64Property: ").append(toIndentedString(integerInt64Property)).append("\n");
+        sb.append("    numberProperty: ").append(toIndentedString(numberProperty)).append("\n");
+        sb.append("    numberFloatProperty: ").append(toIndentedString(numberFloatProperty)).append("\n");
+        sb.append("    numberDoubleProperty: ").append(toIndentedString(numberDoubleProperty)).append("\n");
+        sb.append("    booleanProperty: ").append(toIndentedString(booleanProperty)).append("\n");
+        sb.append("    stringProperty: ").append(toIndentedString(stringProperty)).append("\n");
+        sb.append("    stringByteArrayProperty: ").append(toIndentedString(stringByteArrayProperty)).append("\n");
+        sb.append("    stringDateProperty: ").append(toIndentedString(stringDateProperty)).append("\n");
+        sb.append("    stringDateTimeProperty: ").append(toIndentedString(stringDateTimeProperty)).append("\n");
+        sb.append("    stringNumberProperty: ").append(toIndentedString(stringNumberProperty)).append("\n");
+        sb.append("    stringUuidProperty: ").append(toIndentedString(stringUuidProperty)).append("\n");
+        sb.append("    stringUriProperty: ").append(toIndentedString(stringUriProperty)).append("\n");
+        sb.append("    arrayProperty: ").append(toIndentedString(arrayProperty)).append("\n");
+        sb.append("    arrayUniqueItemsConstraintProperty: ").append(toIndentedString(arrayUniqueItemsConstraintProperty)).append("\n");
+        sb.append("    objectProperty: ").append(toIndentedString(objectProperty)).append("\n");
+        sb.append("    arrayObjectProperty: ").append(toIndentedString(arrayObjectProperty)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/DataTypeVariationTest/supportFileDownload/expected/src/gen/java/org/openapitools/api/DataTypesApi.java
+++ b/src/test/resources/openapi-3_0/DataTypeVariationTest/supportFileDownload/expected/src/gen/java/org/openapitools/api/DataTypesApi.java
@@ -1,0 +1,25 @@
+package org.openapitools.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import nablarch.fw.ExecutionContext;
+import java.io.File;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+
+import jakarta.ws.rs.*;
+
+@Path("/data-types")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-05T14:52:02.759819982+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface DataTypesApi {
+    /**
+     * GET 
+     *
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return OK
+     */
+    @GET
+    HttpResponse dataTypesGet(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/HttpMethodVariationTest/httpMethodsVariation/expected/src/gen/java/org/openapitools/api/HttpMethodsApi.java
+++ b/src/test/resources/openapi-3_0/HttpMethodVariationTest/httpMethodsVariation/expected/src/gen/java/org/openapitools/api/HttpMethodsApi.java
@@ -1,0 +1,95 @@
+package org.openapitools.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+
+import jakarta.ws.rs.*;
+
+@Path("/http-methods")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-10T20:39:01.075738570+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface HttpMethodsApi {
+    /**
+     * GET /get
+     *
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return OK
+     */
+    @GET
+    @Path("/get")
+    @Produces({ "application/json" })
+    EntityResponse<String> httpMethodsGetGet(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * HEAD /head
+     *
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return head
+     */
+    @HEAD
+    @Path("/head")
+    HttpResponse httpMethodsHeadHead(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * OPTIONS /options
+     *
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return options
+     */
+    @OPTIONS
+    @Path("/options")
+    HttpResponse httpMethodsOptionsOptions(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PATCH /patch
+     *
+     *
+     * @param body 
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return OK
+     */
+    @PATCH
+    @Path("/patch")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<String> httpMethodsPatchPatch(String body, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * POST /post
+     *
+     *
+     * @param body 
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return OK
+     */
+    @POST
+    @Path("/post")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<String> httpMethodsPostPost(String body, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /put
+     *
+     *
+     * @param body 
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return OK
+     */
+    @PUT
+    @Path("/put")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    EntityResponse<String> httpMethodsPutPut(String body, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/HttpMethodVariationTest/supported_http_methods.yaml
+++ b/src/test/resources/openapi-3_0/HttpMethodVariationTest/supported_http_methods.yaml
@@ -1,0 +1,84 @@
+---
+openapi: 3.0.3
+info:
+  title: OpenAPI Editor
+  version: 0.0.1
+servers:
+- url: http://localhost:9080
+  description: OpenAPI Editor description
+tags:
+- name: http
+paths:
+  /http-methods/get:
+    get:
+      tags:
+      - http
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+  /http-methods/head:
+    head:
+      tags:
+      - http
+      responses:
+        "200":
+          description: head
+  /http-methods/options:
+    options:
+      tags:
+      - http
+      responses:
+        "200":
+          description: options
+  /http-methods/patch:
+    patch:
+      tags:
+      - http
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+  /http-methods/post:
+    post:
+      tags:
+      - http
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+  /http-methods/put:
+    put:
+      tags:
+      - http
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string

--- a/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/generatePetStore/expected/src/gen/java/org/openapitools/api/PetApi.java
+++ b/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/generatePetStore/expected/src/gen/java/org/openapitools/api/PetApi.java
@@ -1,0 +1,139 @@
+package org.openapitools.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import nablarch.fw.ExecutionContext;
+import java.io.File;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import org.openapitools.model.ModelApiResponse;
+import org.openapitools.model.Pet;
+
+import jakarta.ws.rs.*;
+
+@Path("/pet")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:42:16.980474344+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface PetApi {
+    /**
+     * POST  : Add a new pet to the store
+     *
+     * 
+     *
+     * @param pet Pet object that needs to be added to the store
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return successful operation
+     * @return Invalid input
+     */
+    @POST
+    @Consumes({ "application/json", "application/xml" })
+    @Produces({ "application/xml", "application/json" })
+    EntityResponse<Pet> addPet(Pet pet, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{petId} : Deletes a pet
+     *
+     * 
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return Invalid pet value
+     */
+    @DELETE
+    @Path("/{petId}")
+    HttpResponse deletePet(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /findByStatus : Finds Pets by status
+     *
+     * Multiple status values can be provided with comma separated strings
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return successful operation
+     * @return Invalid status value
+     */
+    @GET
+    @Path("/findByStatus")
+    @Produces({ "application/xml", "application/json" })
+    EntityResponse<List<Pet>> findPetsByStatus(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /findByTags : Finds Pets by tags
+     *
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return successful operation
+     * @return Invalid tag value
+     */
+    @GET
+    @Path("/findByTags")
+    @Produces({ "application/xml", "application/json" })
+    EntityResponse<List<Pet>> findPetsByTags(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{petId} : Find pet by ID
+     *
+     * Returns a single pet
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return successful operation
+     * @return Invalid ID supplied
+     * @return Pet not found
+     */
+    @GET
+    @Path("/{petId}")
+    @Produces({ "application/xml", "application/json" })
+    EntityResponse<Pet> getPetById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT  : Update an existing pet
+     *
+     * 
+     *
+     * @param pet Pet object that needs to be added to the store
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return successful operation
+     * @return Invalid ID supplied
+     * @return Pet not found
+     * @return Validation exception
+     */
+    @PUT
+    @Consumes({ "application/json", "application/xml" })
+    @Produces({ "application/xml", "application/json" })
+    EntityResponse<Pet> updatePet(Pet pet, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * POST /{petId} : Updates a pet in the store with form data
+     *
+     * 
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return Invalid input
+     */
+    @POST
+    @Path("/{petId}")
+    @Consumes({ "application/x-www-form-urlencoded" })
+    HttpResponse updatePetWithForm(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * POST /{petId}/uploadImage : uploads an image
+     *
+     * 
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return successful operation
+     */
+    @POST
+    @Path("/{petId}/uploadImage")
+    @Consumes({ "multipart/form-data" })
+    @Produces({ "application/json" })
+    EntityResponse<ModelApiResponse> uploadFile(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/generatePetStore/expected/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/generatePetStore/expected/src/gen/java/org/openapitools/api/StoreApi.java
@@ -1,0 +1,76 @@
+package org.openapitools.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.Map;
+import org.openapitools.model.Order;
+
+import jakarta.ws.rs.*;
+
+@Path("/store")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:42:16.980474344+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface StoreApi {
+    /**
+     * DELETE /order/{orderId} : Delete purchase order by ID
+     *
+     * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return Invalid ID supplied
+     * @return Order not found
+     */
+    @DELETE
+    @Path("/order/{orderId}")
+    HttpResponse deleteOrder(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /inventory : Returns pet inventories by status
+     *
+     * Returns a map of status codes to quantities
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return successful operation
+     */
+    @GET
+    @Path("/inventory")
+    @Produces({ "application/json" })
+    EntityResponse<Map<String, Integer>> getInventory(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /order/{orderId} : Find purchase order by ID
+     *
+     * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return successful operation
+     * @return Invalid ID supplied
+     * @return Order not found
+     */
+    @GET
+    @Path("/order/{orderId}")
+    @Produces({ "application/xml", "application/json" })
+    EntityResponse<Order> getOrderById(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * POST /order : Place an order for a pet
+     *
+     * 
+     *
+     * @param order order placed for purchasing the pet
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return successful operation
+     * @return Invalid Order
+     */
+    @POST
+    @Path("/order")
+    @Consumes({ "application/json" })
+    @Produces({ "application/xml", "application/json" })
+    EntityResponse<Order> placeOrder(Order order, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/generatePetStore/expected/src/gen/java/org/openapitools/api/UserApi.java
+++ b/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/generatePetStore/expected/src/gen/java/org/openapitools/api/UserApi.java
@@ -1,0 +1,134 @@
+package org.openapitools.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import java.time.OffsetDateTime;
+import org.openapitools.model.User;
+
+import jakarta.ws.rs.*;
+
+@Path("/user")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:42:16.980474344+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface UserApi {
+    /**
+     * POST  : Create user
+     *
+     * This can only be done by the logged in user.
+     *
+     * @param user Created user object
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return successful operation
+     */
+    @POST
+    @Consumes({ "application/json" })
+    HttpResponse createUser(User user, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * POST /createWithArray : Creates list of users with given input array
+     *
+     * 
+     *
+     * @param user List of user object
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return successful operation
+     */
+    @POST
+    @Path("/createWithArray")
+    @Consumes({ "application/json" })
+    HttpResponse createUsersWithArrayInput(List<User> user, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * POST /createWithList : Creates list of users with given input array
+     *
+     * 
+     *
+     * @param user List of user object
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return successful operation
+     */
+    @POST
+    @Path("/createWithList")
+    @Consumes({ "application/json" })
+    HttpResponse createUsersWithListInput(List<User> user, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * DELETE /{username} : Delete user
+     *
+     * This can only be done by the logged in user.
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return Invalid username supplied
+     * @return User not found
+     */
+    @DELETE
+    @Path("/{username}")
+    HttpResponse deleteUser(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /{username} : Get user by user name
+     *
+     * 
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return successful operation
+     * @return Invalid username supplied
+     * @return User not found
+     */
+    @GET
+    @Path("/{username}")
+    @Produces({ "application/xml", "application/json" })
+    EntityResponse<User> getUserByName(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /login : Logs user into the system
+     *
+     * 
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return successful operation
+     * @return Invalid username/password supplied
+     */
+    @GET
+    @Path("/login")
+    @Produces({ "application/xml", "application/json" })
+    EntityResponse<String> loginUser(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * GET /logout : Logs out current logged in user session
+     *
+     * 
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return successful operation
+     */
+    @GET
+    @Path("/logout")
+    HttpResponse logoutUser(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * PUT /{username} : Updated user
+     *
+     * This can only be done by the logged in user.
+     *
+     * @param user Updated user object
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return Invalid user supplied
+     * @return User not found
+     */
+    @PUT
+    @Path("/{username}")
+    @Consumes({ "application/json" })
+    HttpResponse updateUser(User user, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/generatePetStore/expected/src/gen/java/org/openapitools/model/Category.java
+++ b/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/generatePetStore/expected/src/gen/java/org/openapitools/model/Category.java
@@ -1,0 +1,99 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * A category for a pet
+ */
+@JsonTypeName("Category")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:42:16.980474344+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class Category   {
+  private Long id;
+  private String name;
+
+    /**
+     */
+    public Category id(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public Long getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     */
+    public Category name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Category category = (Category) o;
+        return Objects.equals(this.id, category.id) &&
+            Objects.equals(this.name, category.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Category {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/generatePetStore/expected/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/generatePetStore/expected/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -1,0 +1,121 @@
+package org.openapitools.model;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * Describes the result of uploading an image resource
+ */
+@JsonTypeName("ApiResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:42:16.980474344+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ModelApiResponse   {
+  private Integer code;
+  private String type;
+  private String message;
+
+    /**
+     */
+    public ModelApiResponse code(Integer code) {
+        this.code = code;
+        return this;
+    }
+
+    
+    @JsonProperty("code")
+    public Integer getCode() {
+        return code;
+    }
+
+    @JsonProperty("code")
+    public void setCode(Integer code) {
+        this.code = code;
+    }
+
+    /**
+     */
+    public ModelApiResponse type(String type) {
+        this.type = type;
+        return this;
+    }
+
+    
+    @JsonProperty("type")
+    public String getType() {
+        return type;
+    }
+
+    @JsonProperty("type")
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    /**
+     */
+    public ModelApiResponse message(String message) {
+        this.message = message;
+        return this;
+    }
+
+    
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ModelApiResponse _apiResponse = (ModelApiResponse) o;
+        return Objects.equals(this.code, _apiResponse.code) &&
+            Objects.equals(this.type, _apiResponse.type) &&
+            Objects.equals(this.message, _apiResponse.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, type, message);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ModelApiResponse {\n");
+        
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/generatePetStore/expected/src/gen/java/org/openapitools/model/Order.java
+++ b/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/generatePetStore/expected/src/gen/java/org/openapitools/model/Order.java
@@ -1,0 +1,217 @@
+package org.openapitools.model;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * An order for a pets from the pet store
+ */
+@JsonTypeName("Order")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:42:16.980474344+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class Order   {
+  private Long id;
+  private Long petId;
+  private Integer quantity;
+  private OffsetDateTime shipDate;
+  public enum StatusEnum {
+
+    PLACED(String.valueOf("placed")), APPROVED(String.valueOf("approved")), DELIVERED(String.valueOf("delivered"));
+
+
+    private String value;
+
+    StatusEnum (String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static StatusEnum fromValue(String value) {
+        for (StatusEnum b : StatusEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+  private StatusEnum status;
+  private Boolean complete = false;
+
+    /**
+     */
+    public Order id(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public Long getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     */
+    public Order petId(Long petId) {
+        this.petId = petId;
+        return this;
+    }
+
+    
+    @JsonProperty("petId")
+    public Long getPetId() {
+        return petId;
+    }
+
+    @JsonProperty("petId")
+    public void setPetId(Long petId) {
+        this.petId = petId;
+    }
+
+    /**
+     */
+    public Order quantity(Integer quantity) {
+        this.quantity = quantity;
+        return this;
+    }
+
+    
+    @JsonProperty("quantity")
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    @JsonProperty("quantity")
+    public void setQuantity(Integer quantity) {
+        this.quantity = quantity;
+    }
+
+    /**
+     */
+    public Order shipDate(OffsetDateTime shipDate) {
+        this.shipDate = shipDate;
+        return this;
+    }
+
+    
+    @JsonProperty("shipDate")
+    public OffsetDateTime getShipDate() {
+        return shipDate;
+    }
+
+    @JsonProperty("shipDate")
+    public void setShipDate(OffsetDateTime shipDate) {
+        this.shipDate = shipDate;
+    }
+
+    /**
+     * Order Status
+     */
+    public Order status(StatusEnum status) {
+        this.status = status;
+        return this;
+    }
+
+    
+    @JsonProperty("status")
+    public StatusEnum getStatus() {
+        return status;
+    }
+
+    @JsonProperty("status")
+    public void setStatus(StatusEnum status) {
+        this.status = status;
+    }
+
+    /**
+     */
+    public Order complete(Boolean complete) {
+        this.complete = complete;
+        return this;
+    }
+
+    
+    @JsonProperty("complete")
+    public Boolean getComplete() {
+        return complete;
+    }
+
+    @JsonProperty("complete")
+    public void setComplete(Boolean complete) {
+        this.complete = complete;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Order order = (Order) o;
+        return Objects.equals(this.id, order.id) &&
+            Objects.equals(this.petId, order.petId) &&
+            Objects.equals(this.quantity, order.quantity) &&
+            Objects.equals(this.shipDate, order.shipDate) &&
+            Objects.equals(this.status, order.status) &&
+            Objects.equals(this.complete, order.complete);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, petId, quantity, shipDate, status, complete);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Order {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    petId: ").append(toIndentedString(petId)).append("\n");
+        sb.append("    quantity: ").append(toIndentedString(quantity)).append("\n");
+        sb.append("    shipDate: ").append(toIndentedString(shipDate)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("    complete: ").append(toIndentedString(complete)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/generatePetStore/expected/src/gen/java/org/openapitools/model/Pet.java
+++ b/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/generatePetStore/expected/src/gen/java/org/openapitools/model/Pet.java
@@ -1,0 +1,252 @@
+package org.openapitools.model;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.openapitools.model.Category;
+import org.openapitools.model.Tag;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * A pet for sale in the pet store
+ */
+@JsonTypeName("Pet")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:42:16.980474344+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class Pet   {
+  private Long id;
+  private Category category;
+  private String name;
+  private List<String> photoUrls = new ArrayList<>();
+  private List<Tag> tags = new ArrayList<>();
+  public enum StatusEnum {
+
+    AVAILABLE(String.valueOf("available")), PENDING(String.valueOf("pending")), SOLD(String.valueOf("sold"));
+
+
+    private String value;
+
+    StatusEnum (String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static StatusEnum fromValue(String value) {
+        for (StatusEnum b : StatusEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+  private StatusEnum status;
+
+    /**
+     */
+    public Pet id(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public Long getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     */
+    public Pet category(Category category) {
+        this.category = category;
+        return this;
+    }
+
+    
+    @JsonProperty("category")
+    public Category getCategory() {
+        return category;
+    }
+
+    @JsonProperty("category")
+    public void setCategory(Category category) {
+        this.category = category;
+    }
+
+    /**
+     */
+    public Pet name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     */
+    public Pet photoUrls(List<String> photoUrls) {
+        this.photoUrls = photoUrls;
+        return this;
+    }
+
+    
+    @JsonProperty("photoUrls")
+    public List<String> getPhotoUrls() {
+        return photoUrls;
+    }
+
+    @JsonProperty("photoUrls")
+    public void setPhotoUrls(List<String> photoUrls) {
+        this.photoUrls = photoUrls;
+    }
+
+    public Pet addPhotoUrlsItem(String photoUrlsItem) {
+        if (this.photoUrls == null) {
+            this.photoUrls = new ArrayList<>();
+        }
+
+        this.photoUrls.add(photoUrlsItem);
+        return this;
+    }
+
+    public Pet removePhotoUrlsItem(String photoUrlsItem) {
+        if (photoUrlsItem != null && this.photoUrls != null) {
+            this.photoUrls.remove(photoUrlsItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public Pet tags(List<Tag> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    
+    @JsonProperty("tags")
+    public List<Tag> getTags() {
+        return tags;
+    }
+
+    @JsonProperty("tags")
+    public void setTags(List<Tag> tags) {
+        this.tags = tags;
+    }
+
+    public Pet addTagsItem(Tag tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+    public Pet removeTagsItem(Tag tagsItem) {
+        if (tagsItem != null && this.tags != null) {
+            this.tags.remove(tagsItem);
+        }
+
+        return this;
+    }
+    /**
+     * pet status in the store
+     */
+    public Pet status(StatusEnum status) {
+        this.status = status;
+        return this;
+    }
+
+    
+    @JsonProperty("status")
+    public StatusEnum getStatus() {
+        return status;
+    }
+
+    @JsonProperty("status")
+    public void setStatus(StatusEnum status) {
+        this.status = status;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Pet pet = (Pet) o;
+        return Objects.equals(this.id, pet.id) &&
+            Objects.equals(this.category, pet.category) &&
+            Objects.equals(this.name, pet.name) &&
+            Objects.equals(this.photoUrls, pet.photoUrls) &&
+            Objects.equals(this.tags, pet.tags) &&
+            Objects.equals(this.status, pet.status);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, category, name, photoUrls, tags, status);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Pet {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    category: ").append(toIndentedString(category)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    photoUrls: ").append(toIndentedString(photoUrls)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/generatePetStore/expected/src/gen/java/org/openapitools/model/Tag.java
+++ b/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/generatePetStore/expected/src/gen/java/org/openapitools/model/Tag.java
@@ -1,0 +1,99 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * A tag for a pet
+ */
+@JsonTypeName("Tag")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:42:16.980474344+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class Tag   {
+  private Long id;
+  private String name;
+
+    /**
+     */
+    public Tag id(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public Long getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     */
+    public Tag name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Tag tag = (Tag) o;
+        return Objects.equals(this.id, tag.id) &&
+            Objects.equals(this.name, tag.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Tag {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/generatePetStore/expected/src/gen/java/org/openapitools/model/User.java
+++ b/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/generatePetStore/expected/src/gen/java/org/openapitools/model/User.java
@@ -1,0 +1,226 @@
+package org.openapitools.model;
+
+import java.util.Arrays;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * A User who is purchasing from the pet store
+ */
+@JsonTypeName("User")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:42:16.980474344+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class User   {
+  private Long id;
+  private String username;
+  private String firstName;
+  private String lastName;
+  private String email;
+  private String password;
+  private String phone;
+  private Integer userStatus;
+
+    /**
+     */
+    public User id(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    
+    @JsonProperty("id")
+    public Long getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     */
+    public User username(String username) {
+        this.username = username;
+        return this;
+    }
+
+    
+    @JsonProperty("username")
+    public String getUsername() {
+        return username;
+    }
+
+    @JsonProperty("username")
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    /**
+     */
+    public User firstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    
+    @JsonProperty("firstName")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("firstName")
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     */
+    public User lastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    
+    @JsonProperty("lastName")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("lastName")
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     */
+    public User email(String email) {
+        this.email = email;
+        return this;
+    }
+
+    
+    @JsonProperty("email")
+    public String getEmail() {
+        return email;
+    }
+
+    @JsonProperty("email")
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    /**
+     */
+    public User password(String password) {
+        this.password = password;
+        return this;
+    }
+
+    
+    @JsonProperty("password")
+    public String getPassword() {
+        return password;
+    }
+
+    @JsonProperty("password")
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    /**
+     */
+    public User phone(String phone) {
+        this.phone = phone;
+        return this;
+    }
+
+    
+    @JsonProperty("phone")
+    public String getPhone() {
+        return phone;
+    }
+
+    @JsonProperty("phone")
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    /**
+     * User Status
+     */
+    public User userStatus(Integer userStatus) {
+        this.userStatus = userStatus;
+        return this;
+    }
+
+    
+    @JsonProperty("userStatus")
+    public Integer getUserStatus() {
+        return userStatus;
+    }
+
+    @JsonProperty("userStatus")
+    public void setUserStatus(Integer userStatus) {
+        this.userStatus = userStatus;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        User user = (User) o;
+        return Objects.equals(this.id, user.id) &&
+            Objects.equals(this.username, user.username) &&
+            Objects.equals(this.firstName, user.firstName) &&
+            Objects.equals(this.lastName, user.lastName) &&
+            Objects.equals(this.email, user.email) &&
+            Objects.equals(this.password, user.password) &&
+            Objects.equals(this.phone, user.phone) &&
+            Objects.equals(this.userStatus, user.userStatus);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, username, firstName, lastName, email, password, phone, userStatus);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class User {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    username: ").append(toIndentedString(username)).append("\n");
+        sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+        sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+        sb.append("    email: ").append(toIndentedString(email)).append("\n");
+        sb.append("    password: ").append(toIndentedString(password)).append("\n");
+        sb.append("    phone: ").append(toIndentedString(phone)).append("\n");
+        sb.append("    userStatus: ").append(toIndentedString(userStatus)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/generatePing/expected/src/gen/java/org/openapitools/api/PingApi.java
+++ b/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/generatePing/expected/src/gen/java/org/openapitools/api/PingApi.java
@@ -1,0 +1,24 @@
+package org.openapitools.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+
+import jakarta.ws.rs.*;
+
+@Path("/ping")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-11-29T21:02:26.826484049+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface PingApi {
+    /**
+     * GET 
+     *
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return OK
+     */
+    @GET
+    HttpResponse pingGet(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/petstore.yaml
+++ b/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/petstore.yaml
@@ -1,0 +1,741 @@
+openapi: 3.0.0
+servers:
+  - url: 'http://petstore.swagger.io/v2'
+info:
+  description: >-
+    This is a sample server Petstore server. For this sample, you can use the api key
+    `special-key` to test the authorization filters.
+  version: 1.0.0
+  title: OpenAPI Petstore
+  license:
+    name: Apache-2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+tags:
+  - name: pet
+    description: Everything about your Pets
+  - name: store
+    description: Access to Petstore orders
+  - name: user
+    description: Operations about user
+paths:
+  /pet:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: ''
+      operationId: addPet
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '405':
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      requestBody:
+        $ref: '#/components/requestBodies/Pet'
+    put:
+      tags:
+        - pet
+      summary: Update an existing pet
+      description: ''
+      operationId: updatePet
+      externalDocs:
+        url: "http://petstore.swagger.io/v2/doc/updatePet"
+        description: "API documentation for the updatePet operation"
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+        '405':
+          description: Validation exception
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      requestBody:
+        $ref: '#/components/requestBodies/Pet'
+  /pet/findByStatus:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: true
+          style: form
+          explode: false
+          deprecated: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - available
+                - pending
+                - sold
+              default: available
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid status value
+      security:
+        - petstore_auth:
+            - 'read:pets'
+  /pet/findByTags:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by tags
+      description: >-
+        Multiple tags can be provided with comma separated strings. Use tag1,
+        tag2, tag3 for testing.
+      operationId: findPetsByTags
+      parameters:
+        - name: tags
+          in: query
+          description: Tags to filter by
+          required: true
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid tag value
+      security:
+        - petstore_auth:
+            - 'read:pets'
+      deprecated: true
+  '/pet/{petId}':
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+      security:
+        - api_key: []
+    post:
+      tags:
+        - pet
+      summary: Updates a pet in the store with form data
+      description: ''
+      operationId: updatePetWithForm
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet that needs to be updated
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '405':
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: Updated name of the pet
+                  type: string
+                status:
+                  description: Updated status of the pet
+                  type: string
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: ''
+      operationId: deletePet
+      parameters:
+        - name: api_key
+          in: header
+          required: false
+          schema:
+            type: string
+        - name: petId
+          in: path
+          description: Pet id to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '400':
+          description: Invalid pet value
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+  '/pet/{petId}/uploadImage':
+    post:
+      tags:
+        - pet
+      summary: uploads an image
+      description: ''
+      operationId: uploadFile
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to update
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                additionalMetadata:
+                  description: Additional data to pass to server
+                  type: string
+                file:
+                  description: file to upload
+                  type: string
+                  format: binary
+  /store/inventory:
+    get:
+      tags:
+        - store
+      summary: Returns pet inventories by status
+      description: Returns a map of status codes to quantities
+      operationId: getInventory
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32
+      security:
+        - api_key: []
+  /store/order:
+    post:
+      tags:
+        - store
+      summary: Place an order for a pet
+      description: ''
+      operationId: placeOrder
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Order'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+        '400':
+          description: Invalid Order
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Order'
+        description: order placed for purchasing the pet
+        required: true
+  '/store/order/{orderId}':
+    get:
+      tags:
+        - store
+      summary: Find purchase order by ID
+      description: >-
+        For valid response try integer IDs with value <= 5 or > 10. Other values
+        will generate exceptions
+      operationId: getOrderById
+      parameters:
+        - name: orderId
+          in: path
+          description: ID of pet that needs to be fetched
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            maximum: 5
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Order'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Order not found
+    delete:
+      tags:
+        - store
+      summary: Delete purchase order by ID
+      description: >-
+        For valid response try integer IDs with value < 1000. Anything above
+        1000 or nonintegers will generate API errors
+      operationId: deleteOrder
+      parameters:
+        - name: orderId
+          in: path
+          description: ID of the order that needs to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Order not found
+  /user:
+    post:
+      tags:
+        - user
+      summary: Create user
+      description: This can only be done by the logged in user.
+      operationId: createUser
+      responses:
+        default:
+          description: successful operation
+      security:
+        - api_key: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+        description: Created user object
+        required: true
+  /user/createWithArray:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ''
+      operationId: createUsersWithArrayInput
+      responses:
+        default:
+          description: successful operation
+      security:
+        - api_key: []
+      requestBody:
+        $ref: '#/components/requestBodies/UserArray'
+  /user/createWithList:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ''
+      operationId: createUsersWithListInput
+      responses:
+        default:
+          description: successful operation
+      security:
+        - api_key: []
+      requestBody:
+        $ref: '#/components/requestBodies/UserArray'
+  /user/login:
+    get:
+      tags:
+        - user
+      summary: Logs user into the system
+      description: ''
+      operationId: loginUser
+      parameters:
+        - name: username
+          in: query
+          description: The user name for login
+          required: true
+          schema:
+            type: string
+            pattern: '^[a-zA-Z0-9]+[a-zA-Z0-9\.\-_]*[a-zA-Z0-9]+$'
+        - name: password
+          in: query
+          description: The password for login in clear text
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          headers:
+            Set-Cookie:
+              description: >-
+                Cookie authentication key for use with the `api_key`
+                apiKey authentication.
+              schema:
+                type: string
+                example: AUTH_KEY=abcde12345; Path=/; HttpOnly
+            X-Rate-Limit:
+              description: calls per hour allowed by the user
+              schema:
+                type: integer
+                format: int32
+            X-Expires-After:
+              description: date in UTC when token expires
+              schema:
+                type: string
+                format: date-time
+          content:
+            application/xml:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: string
+        '400':
+          description: Invalid username/password supplied
+  /user/logout:
+    get:
+      tags:
+        - user
+      summary: Logs out current logged in user session
+      description: ''
+      operationId: logoutUser
+      responses:
+        default:
+          description: successful operation
+      security:
+        - api_key: []
+  '/user/{username}':
+    get:
+      tags:
+        - user
+      summary: Get user by user name
+      description: ''
+      operationId: getUserByName
+      parameters:
+        - name: username
+          in: path
+          description: The name that needs to be fetched. Use user1 for testing.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/User'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '400':
+          description: Invalid username supplied
+        '404':
+          description: User not found
+    put:
+      tags:
+        - user
+      summary: Updated user
+      description: This can only be done by the logged in user.
+      operationId: updateUser
+      parameters:
+        - name: username
+          in: path
+          description: name that need to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid user supplied
+        '404':
+          description: User not found
+      security:
+        - api_key: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+        description: Updated user object
+        required: true
+    delete:
+      tags:
+        - user
+      summary: Delete user
+      description: This can only be done by the logged in user.
+      operationId: deleteUser
+      parameters:
+        - name: username
+          in: path
+          description: The name that needs to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid username supplied
+        '404':
+          description: User not found
+      security:
+        - api_key: []
+externalDocs:
+  description: Find out more about Swagger
+  url: 'http://swagger.io'
+components:
+  requestBodies:
+    UserArray:
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/User'
+      description: List of user object
+      required: true
+    Pet:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Pet'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/Pet'
+      description: Pet object that needs to be added to the store
+      required: true
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: 'http://petstore.swagger.io/api/oauth/dialog'
+          scopes:
+            'write:pets': modify pets in your account
+            'read:pets': read your pets
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+  schemas:
+    Order:
+      title: Pet Order
+      description: An order for a pets from the pet store
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        petId:
+          type: integer
+          format: int64
+        quantity:
+          type: integer
+          format: int32
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          enum:
+            - placed
+            - approved
+            - delivered
+        complete:
+          type: boolean
+          default: false
+      xml:
+        name: Order
+    Category:
+      title: Pet category
+      description: A category for a pet
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+          pattern: '^[a-zA-Z0-9]+[a-zA-Z0-9\.\-_]*[a-zA-Z0-9]+$'
+      xml:
+        name: Category
+    User:
+      title: a User
+      description: A User who is purchasing from the pet store
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        username:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+        password:
+          type: string
+        phone:
+          type: string
+        userStatus:
+          type: integer
+          format: int32
+          description: User Status
+      xml:
+        name: User
+    Tag:
+      title: Pet Tag
+      description: A tag for a pet
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Tag
+    Pet:
+      title: a Pet
+      description: A pet for sale in the pet store
+      type: object
+      required:
+        - name
+        - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+        category:
+          $ref: '#/components/schemas/Category'
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            $ref: '#/components/schemas/Tag'
+        status:
+          type: string
+          description: pet status in the store
+          deprecated: true
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: Pet
+    ApiResponse:
+      title: An uploaded response
+      description: Describes the result of uploading an image resource
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        type:
+          type: string
+        message:
+          type: string

--- a/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/ping.yaml
+++ b/src/test/resources/openapi-3_0/OpenApiGeneratorSpecBenchmarkTest/ping.yaml
@@ -1,0 +1,13 @@
+openapi: 3.0.3
+info:
+  title: ping test
+  version: '1.0'
+servers:
+  - url: 'http://localhost:8080/'
+paths:
+  /ping:
+    get:
+      operationId: pingGet
+      responses:
+        '201':
+          description: OK

--- a/src/test/resources/openapi-3_0/ValidationVariationTest/allSupportedValidations/expected/src/gen/java/org/openapitools/api/ValidationsApi.java
+++ b/src/test/resources/openapi-3_0/ValidationVariationTest/allSupportedValidations/expected/src/gen/java/org/openapitools/api/ValidationsApi.java
@@ -1,0 +1,44 @@
+package org.openapitools.api;
+
+import nablarch.fw.jaxrs.EntityResponse;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import java.util.List;
+import jakarta.validation.Valid;
+import org.openapitools.model.ValidationRequest;
+import org.openapitools.model.ValidationResponse;
+
+import jakarta.ws.rs.*;
+
+@Path("/validations")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:40:02.319711249+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public interface ValidationsApi {
+    /**
+     * GET 
+     *
+     *
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return OK
+     */
+    @GET
+    @Produces({ "application/json" })
+    EntityResponse<List<ValidationResponse>> validationsGet(JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+    /**
+     * POST 
+     *
+     *
+     * @param validationRequest 
+     * @param jaxRsHttpRequest HTTPリクエスト
+     * @param context ハンドラ実行コンテキスト
+     * @return OK
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @Valid
+    EntityResponse<ValidationResponse> validationsPost(ValidationRequest validationRequest, JaxRsHttpRequest jaxRsHttpRequest, ExecutionContext context);
+
+}

--- a/src/test/resources/openapi-3_0/ValidationVariationTest/allSupportedValidations/expected/src/gen/java/org/openapitools/model/ValidationRequest.java
+++ b/src/test/resources/openapi-3_0/ValidationVariationTest/allSupportedValidations/expected/src/gen/java/org/openapitools/model/ValidationRequest.java
@@ -1,0 +1,2791 @@
+package org.openapitools.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import nablarch.core.validation.ee.DecimalRange;
+import nablarch.core.validation.ee.Length;
+import nablarch.core.validation.ee.NumberRange;
+import nablarch.core.validation.ee.Required;
+import nablarch.core.validation.ee.Size;
+import org.openapitools.model.ValidationSubRequest;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+
+@JsonTypeName("ValidationRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:40:02.319711249+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ValidationRequest   {
+  private Integer integerPlainProperty;
+  private Integer integerRequiredProperty;
+  private Integer integerMinimumProperty;
+  private Integer integerMaximumProperty;
+  private Integer integerMinimumMaximumProperty;
+  private Integer integerRequiredMinimumMaximumProperty;
+  private Integer integerInt32PlainProperty;
+  private Integer integerInt32RequiredProperty;
+  private Integer integerInt32MinimumProperty;
+  private Integer integerInt32MaximumProperty;
+  private Integer integerInt32MinimumMaximumProperty;
+  private Integer integerInt32RequiredMinimumMaximumProperty;
+  private Long integerInt64PlainProperty;
+  private Long integerInt64RequiredProperty;
+  private Long integerInt64MinimumProperty;
+  private Long integerInt64MaximumProperty;
+  private Long integerInt64MinimumMaximumProperty;
+  private Long integerInt64RequiredMinimumMaximumProperty;
+  private BigDecimal numberPlainProperty;
+  private BigDecimal numberRequiredProperty;
+  private BigDecimal numberMinimumProperty;
+  private BigDecimal numberMaximumProperty;
+  private BigDecimal numberMinimumMaximumProperty;
+  private BigDecimal numberRequiredMinimumMaximumProperty;
+  private Float numberFloatPlainProperty;
+  private Float numberFloatRequiredProperty;
+  private Float numberFloatMinimumProperty;
+  private Float numberFloatMaximumProperty;
+  private Float numberFloatMinimumMaximumProperty;
+  private Float numberFloatRequiredMinimumMaximumProperty;
+  private Double numberDoublePlainProperty;
+  private Double numberDoubleRequiredProperty;
+  private Double numberDoubleMinimumProperty;
+  private Double numberDoubleMaximumProperty;
+  private Double numberDoubleMinimumMaximumProperty;
+  private Double numberDoubleRequiredMinimumMaximumProperty;
+  private Boolean booleanPlainProperty;
+  private Boolean booleanRequiredProperty;
+  private String stringPlainProperty;
+  private String stringRequiredProperty;
+  private String stringMinLengthProperty;
+  private String stringMaxLengthProperty;
+  private String stringMinLengthMaxLengthProperty;
+  private String stringPatternProperty;
+  private String stringRequiredMinLengthMaxLengthPatternProperty;
+  private byte[] stringByteArrayProperty;
+  private byte[] stringByteArrayMinLengthProperty;
+  private byte[] stringByteArrayMaxLengthProperty;
+  private byte[] stringByteArrayMinLengthMaxLengthProperty;
+  private byte[] stringByteArrayRequiredMinLengthMaxLengthProperty;
+  private LocalDate stringDatePlainProperty;
+  private LocalDate stringDateRequiredProperty;
+  private OffsetDateTime stringDateTimePlainProperty;
+  private OffsetDateTime stringDateTimeRequiredProperty;
+  private String stringPasswordPlainProperty;
+  private String stringPasswordRequiredProperty;
+  private String stringPasswordMinLengthProperty;
+  private String stringPasswordMaxLengthProperty;
+  private String stringPasswordMinLengthMaxLengthProperty;
+  private String stringPasswordPatternProperty;
+  private String stringPasswordRequiredMinLengthMaxLengthPatternProperty;
+  private BigDecimal stringNumberPlainProperty;
+  private BigDecimal stringNumberRequiredProperty;
+  private URI stringUriPlainProperty;
+  private URI stringUriRequiredProperty;
+  private UUID stringUuidPlainProperty;
+  private UUID stringUuidRequiredProperty;
+  private String stringRegexPlainProperty;
+  private String stringRegexRequiredProperty;
+  private String stringRegexMinLengthProperty;
+  private String stringRegexMaxLengthProperty;
+  private String stringRegexMinLengthMaxLengthProperty;
+  private String stringRegexRequiredMinLengthMaxLengthProperty;
+  private @Valid List<String> arrayStringPlainProperty = new ArrayList<>();
+  private @Valid List<String> arrayStringRequiredProperty = new ArrayList<>();
+  private @Valid List<String> arrayStringMinItemsProperty = new ArrayList<>();
+  private @Valid List<String> arrayStringMaxItemsProperty = new ArrayList<>();
+  private @Valid List<String> arrayStringMinItemsMaxItemsProperty = new ArrayList<>();
+  private @Valid List<String> arrayStringRequiredMinItemsMaxItemsProperty = new ArrayList<>();
+  private @Valid List<@Valid ValidationSubRequest> arrayObjectPlainProperty = new ArrayList<>();
+  private @Valid List<@Valid ValidationSubRequest> arrayObjectRequiredProperty = new ArrayList<>();
+  private @Valid List<@Valid ValidationSubRequest> arrayObjectMinItemsProperty = new ArrayList<>();
+  private @Valid List<@Valid ValidationSubRequest> arrayObjectMaxItemsProperty = new ArrayList<>();
+  private @Valid List<@Valid ValidationSubRequest> arrayObjectMinItemsMaxItemsProperty = new ArrayList<>();
+  private @Valid List<@Valid ValidationSubRequest> arrayObjectRequiredMinItemsMaxItemsProperty = new ArrayList<>();
+  private @Valid Set<String> arrayStringUniqueItemsPlainProperty = new LinkedHashSet<>();
+  private @Valid Set<String> arrayStringUniqueItemsRequiredProperty = new LinkedHashSet<>();
+  private @Valid Set<String> arrayStringUniqueItemsMinItemsProperty = new LinkedHashSet<>();
+  private @Valid Set<String> arrayStringUniqueItemsMaxItemsProperty = new LinkedHashSet<>();
+  private @Valid Set<String> arrayStringUniqueItemsMinItemsMaxItemsProperty = new LinkedHashSet<>();
+  private @Valid Set<String> arrayStringUniqueItemsRequiredMinItemsMaxItemsProperty = new LinkedHashSet<>();
+  private @Valid Set<@Valid ValidationSubRequest> arrayObjectUniqueItemsPlainProperty = new LinkedHashSet<>();
+  private @Valid Set<@Valid ValidationSubRequest> arrayObjectUniqueItemsRequiredProperty = new LinkedHashSet<>();
+  private @Valid Set<@Valid ValidationSubRequest> arrayObjectUniqueItemsMinItemsProperty = new LinkedHashSet<>();
+  private @Valid Set<@Valid ValidationSubRequest> arrayObjectUniqueItemsMaxItemsProperty = new LinkedHashSet<>();
+  private @Valid Set<@Valid ValidationSubRequest> arrayObjectUniqueItemsMinItemsMaxItemsProperty = new LinkedHashSet<>();
+  private @Valid Set<@Valid ValidationSubRequest> arrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty = new LinkedHashSet<>();
+  private ValidationSubRequest objectPlainProperty;
+  private ValidationSubRequest objectRequiredProperty;
+  public enum EnumPlainPropertyEnum {
+
+    ACTIVE(String.valueOf("active")), INACTIVE(String.valueOf("inactive"));
+
+
+    private String value;
+
+    EnumPlainPropertyEnum (String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static EnumPlainPropertyEnum fromValue(String value) {
+        for (EnumPlainPropertyEnum b : EnumPlainPropertyEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+  private EnumPlainPropertyEnum enumPlainProperty;
+  public enum EnumRequiredPropertyEnum {
+
+    ACTIVE(String.valueOf("active")), INACTIVE(String.valueOf("inactive"));
+
+
+    private String value;
+
+    EnumRequiredPropertyEnum (String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static EnumRequiredPropertyEnum fromValue(String value) {
+        for (EnumRequiredPropertyEnum b : EnumRequiredPropertyEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+  private EnumRequiredPropertyEnum enumRequiredProperty;
+
+    /**
+     */
+    public ValidationRequest integerPlainProperty(Integer integerPlainProperty) {
+        this.integerPlainProperty = integerPlainProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerPlainProperty")
+    
+    public Integer getIntegerPlainProperty() {
+        return integerPlainProperty;
+    }
+
+    @JsonProperty("integerPlainProperty")
+    public void setIntegerPlainProperty(Integer integerPlainProperty) {
+        this.integerPlainProperty = integerPlainProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest integerRequiredProperty(Integer integerRequiredProperty) {
+        this.integerRequiredProperty = integerRequiredProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerRequiredProperty")
+    @Required 
+    public Integer getIntegerRequiredProperty() {
+        return integerRequiredProperty;
+    }
+
+    @JsonProperty("integerRequiredProperty")
+    public void setIntegerRequiredProperty(Integer integerRequiredProperty) {
+        this.integerRequiredProperty = integerRequiredProperty;
+    }
+
+    /**
+     * minimum: 3
+     */
+    public ValidationRequest integerMinimumProperty(Integer integerMinimumProperty) {
+        this.integerMinimumProperty = integerMinimumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerMinimumProperty")
+    @NumberRange(min = 3) 
+    public Integer getIntegerMinimumProperty() {
+        return integerMinimumProperty;
+    }
+
+    @JsonProperty("integerMinimumProperty")
+    public void setIntegerMinimumProperty(Integer integerMinimumProperty) {
+        this.integerMinimumProperty = integerMinimumProperty;
+    }
+
+    /**
+     * maximum: 7
+     */
+    public ValidationRequest integerMaximumProperty(Integer integerMaximumProperty) {
+        this.integerMaximumProperty = integerMaximumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerMaximumProperty")
+    @NumberRange(max = 7) 
+    public Integer getIntegerMaximumProperty() {
+        return integerMaximumProperty;
+    }
+
+    @JsonProperty("integerMaximumProperty")
+    public void setIntegerMaximumProperty(Integer integerMaximumProperty) {
+        this.integerMaximumProperty = integerMaximumProperty;
+    }
+
+    /**
+     * minimum: 3
+     * maximum: 7
+     */
+    public ValidationRequest integerMinimumMaximumProperty(Integer integerMinimumMaximumProperty) {
+        this.integerMinimumMaximumProperty = integerMinimumMaximumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerMinimumMaximumProperty")
+    @NumberRange(min = 3, max = 7) 
+    public Integer getIntegerMinimumMaximumProperty() {
+        return integerMinimumMaximumProperty;
+    }
+
+    @JsonProperty("integerMinimumMaximumProperty")
+    public void setIntegerMinimumMaximumProperty(Integer integerMinimumMaximumProperty) {
+        this.integerMinimumMaximumProperty = integerMinimumMaximumProperty;
+    }
+
+    /**
+     * minimum: 3
+     * maximum: 7
+     */
+    public ValidationRequest integerRequiredMinimumMaximumProperty(Integer integerRequiredMinimumMaximumProperty) {
+        this.integerRequiredMinimumMaximumProperty = integerRequiredMinimumMaximumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerRequiredMinimumMaximumProperty")
+    @Required @NumberRange(min = 3, max = 7) 
+    public Integer getIntegerRequiredMinimumMaximumProperty() {
+        return integerRequiredMinimumMaximumProperty;
+    }
+
+    @JsonProperty("integerRequiredMinimumMaximumProperty")
+    public void setIntegerRequiredMinimumMaximumProperty(Integer integerRequiredMinimumMaximumProperty) {
+        this.integerRequiredMinimumMaximumProperty = integerRequiredMinimumMaximumProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest integerInt32PlainProperty(Integer integerInt32PlainProperty) {
+        this.integerInt32PlainProperty = integerInt32PlainProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt32PlainProperty")
+    
+    public Integer getIntegerInt32PlainProperty() {
+        return integerInt32PlainProperty;
+    }
+
+    @JsonProperty("integerInt32PlainProperty")
+    public void setIntegerInt32PlainProperty(Integer integerInt32PlainProperty) {
+        this.integerInt32PlainProperty = integerInt32PlainProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest integerInt32RequiredProperty(Integer integerInt32RequiredProperty) {
+        this.integerInt32RequiredProperty = integerInt32RequiredProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt32RequiredProperty")
+    @Required 
+    public Integer getIntegerInt32RequiredProperty() {
+        return integerInt32RequiredProperty;
+    }
+
+    @JsonProperty("integerInt32RequiredProperty")
+    public void setIntegerInt32RequiredProperty(Integer integerInt32RequiredProperty) {
+        this.integerInt32RequiredProperty = integerInt32RequiredProperty;
+    }
+
+    /**
+     * minimum: 3
+     */
+    public ValidationRequest integerInt32MinimumProperty(Integer integerInt32MinimumProperty) {
+        this.integerInt32MinimumProperty = integerInt32MinimumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt32MinimumProperty")
+    @NumberRange(min = 3) 
+    public Integer getIntegerInt32MinimumProperty() {
+        return integerInt32MinimumProperty;
+    }
+
+    @JsonProperty("integerInt32MinimumProperty")
+    public void setIntegerInt32MinimumProperty(Integer integerInt32MinimumProperty) {
+        this.integerInt32MinimumProperty = integerInt32MinimumProperty;
+    }
+
+    /**
+     * maximum: 7
+     */
+    public ValidationRequest integerInt32MaximumProperty(Integer integerInt32MaximumProperty) {
+        this.integerInt32MaximumProperty = integerInt32MaximumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt32MaximumProperty")
+    @NumberRange(max = 7) 
+    public Integer getIntegerInt32MaximumProperty() {
+        return integerInt32MaximumProperty;
+    }
+
+    @JsonProperty("integerInt32MaximumProperty")
+    public void setIntegerInt32MaximumProperty(Integer integerInt32MaximumProperty) {
+        this.integerInt32MaximumProperty = integerInt32MaximumProperty;
+    }
+
+    /**
+     * minimum: 3
+     * maximum: 7
+     */
+    public ValidationRequest integerInt32MinimumMaximumProperty(Integer integerInt32MinimumMaximumProperty) {
+        this.integerInt32MinimumMaximumProperty = integerInt32MinimumMaximumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt32MinimumMaximumProperty")
+    @NumberRange(min = 3, max = 7) 
+    public Integer getIntegerInt32MinimumMaximumProperty() {
+        return integerInt32MinimumMaximumProperty;
+    }
+
+    @JsonProperty("integerInt32MinimumMaximumProperty")
+    public void setIntegerInt32MinimumMaximumProperty(Integer integerInt32MinimumMaximumProperty) {
+        this.integerInt32MinimumMaximumProperty = integerInt32MinimumMaximumProperty;
+    }
+
+    /**
+     * minimum: 3
+     * maximum: 7
+     */
+    public ValidationRequest integerInt32RequiredMinimumMaximumProperty(Integer integerInt32RequiredMinimumMaximumProperty) {
+        this.integerInt32RequiredMinimumMaximumProperty = integerInt32RequiredMinimumMaximumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt32RequiredMinimumMaximumProperty")
+    @Required @NumberRange(min = 3, max = 7) 
+    public Integer getIntegerInt32RequiredMinimumMaximumProperty() {
+        return integerInt32RequiredMinimumMaximumProperty;
+    }
+
+    @JsonProperty("integerInt32RequiredMinimumMaximumProperty")
+    public void setIntegerInt32RequiredMinimumMaximumProperty(Integer integerInt32RequiredMinimumMaximumProperty) {
+        this.integerInt32RequiredMinimumMaximumProperty = integerInt32RequiredMinimumMaximumProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest integerInt64PlainProperty(Long integerInt64PlainProperty) {
+        this.integerInt64PlainProperty = integerInt64PlainProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt64PlainProperty")
+    
+    public Long getIntegerInt64PlainProperty() {
+        return integerInt64PlainProperty;
+    }
+
+    @JsonProperty("integerInt64PlainProperty")
+    public void setIntegerInt64PlainProperty(Long integerInt64PlainProperty) {
+        this.integerInt64PlainProperty = integerInt64PlainProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest integerInt64RequiredProperty(Long integerInt64RequiredProperty) {
+        this.integerInt64RequiredProperty = integerInt64RequiredProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt64RequiredProperty")
+    @Required 
+    public Long getIntegerInt64RequiredProperty() {
+        return integerInt64RequiredProperty;
+    }
+
+    @JsonProperty("integerInt64RequiredProperty")
+    public void setIntegerInt64RequiredProperty(Long integerInt64RequiredProperty) {
+        this.integerInt64RequiredProperty = integerInt64RequiredProperty;
+    }
+
+    /**
+     * minimum: 3
+     */
+    public ValidationRequest integerInt64MinimumProperty(Long integerInt64MinimumProperty) {
+        this.integerInt64MinimumProperty = integerInt64MinimumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt64MinimumProperty")
+    @NumberRange(min = 3) 
+    public Long getIntegerInt64MinimumProperty() {
+        return integerInt64MinimumProperty;
+    }
+
+    @JsonProperty("integerInt64MinimumProperty")
+    public void setIntegerInt64MinimumProperty(Long integerInt64MinimumProperty) {
+        this.integerInt64MinimumProperty = integerInt64MinimumProperty;
+    }
+
+    /**
+     * maximum: 7
+     */
+    public ValidationRequest integerInt64MaximumProperty(Long integerInt64MaximumProperty) {
+        this.integerInt64MaximumProperty = integerInt64MaximumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt64MaximumProperty")
+    @NumberRange(max = 7) 
+    public Long getIntegerInt64MaximumProperty() {
+        return integerInt64MaximumProperty;
+    }
+
+    @JsonProperty("integerInt64MaximumProperty")
+    public void setIntegerInt64MaximumProperty(Long integerInt64MaximumProperty) {
+        this.integerInt64MaximumProperty = integerInt64MaximumProperty;
+    }
+
+    /**
+     * minimum: 3
+     * maximum: 7
+     */
+    public ValidationRequest integerInt64MinimumMaximumProperty(Long integerInt64MinimumMaximumProperty) {
+        this.integerInt64MinimumMaximumProperty = integerInt64MinimumMaximumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt64MinimumMaximumProperty")
+    @NumberRange(min = 3, max = 7) 
+    public Long getIntegerInt64MinimumMaximumProperty() {
+        return integerInt64MinimumMaximumProperty;
+    }
+
+    @JsonProperty("integerInt64MinimumMaximumProperty")
+    public void setIntegerInt64MinimumMaximumProperty(Long integerInt64MinimumMaximumProperty) {
+        this.integerInt64MinimumMaximumProperty = integerInt64MinimumMaximumProperty;
+    }
+
+    /**
+     * minimum: 3
+     * maximum: 7
+     */
+    public ValidationRequest integerInt64RequiredMinimumMaximumProperty(Long integerInt64RequiredMinimumMaximumProperty) {
+        this.integerInt64RequiredMinimumMaximumProperty = integerInt64RequiredMinimumMaximumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("integerInt64RequiredMinimumMaximumProperty")
+    @Required @NumberRange(min = 3, max = 7) 
+    public Long getIntegerInt64RequiredMinimumMaximumProperty() {
+        return integerInt64RequiredMinimumMaximumProperty;
+    }
+
+    @JsonProperty("integerInt64RequiredMinimumMaximumProperty")
+    public void setIntegerInt64RequiredMinimumMaximumProperty(Long integerInt64RequiredMinimumMaximumProperty) {
+        this.integerInt64RequiredMinimumMaximumProperty = integerInt64RequiredMinimumMaximumProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest numberPlainProperty(BigDecimal numberPlainProperty) {
+        this.numberPlainProperty = numberPlainProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberPlainProperty")
+    @Valid 
+    public BigDecimal getNumberPlainProperty() {
+        return numberPlainProperty;
+    }
+
+    @JsonProperty("numberPlainProperty")
+    public void setNumberPlainProperty(BigDecimal numberPlainProperty) {
+        this.numberPlainProperty = numberPlainProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest numberRequiredProperty(BigDecimal numberRequiredProperty) {
+        this.numberRequiredProperty = numberRequiredProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberRequiredProperty")
+    @Required @Valid 
+    public BigDecimal getNumberRequiredProperty() {
+        return numberRequiredProperty;
+    }
+
+    @JsonProperty("numberRequiredProperty")
+    public void setNumberRequiredProperty(BigDecimal numberRequiredProperty) {
+        this.numberRequiredProperty = numberRequiredProperty;
+    }
+
+    /**
+     * minimum: 3.2
+     */
+    public ValidationRequest numberMinimumProperty(BigDecimal numberMinimumProperty) {
+        this.numberMinimumProperty = numberMinimumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberMinimumProperty")
+    @Valid @DecimalRange(min = "3.2") 
+    public BigDecimal getNumberMinimumProperty() {
+        return numberMinimumProperty;
+    }
+
+    @JsonProperty("numberMinimumProperty")
+    public void setNumberMinimumProperty(BigDecimal numberMinimumProperty) {
+        this.numberMinimumProperty = numberMinimumProperty;
+    }
+
+    /**
+     * maximum: 7.5
+     */
+    public ValidationRequest numberMaximumProperty(BigDecimal numberMaximumProperty) {
+        this.numberMaximumProperty = numberMaximumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberMaximumProperty")
+    @Valid @DecimalRange(max = "7.5") 
+    public BigDecimal getNumberMaximumProperty() {
+        return numberMaximumProperty;
+    }
+
+    @JsonProperty("numberMaximumProperty")
+    public void setNumberMaximumProperty(BigDecimal numberMaximumProperty) {
+        this.numberMaximumProperty = numberMaximumProperty;
+    }
+
+    /**
+     * minimum: 3.2
+     * maximum: 7.5
+     */
+    public ValidationRequest numberMinimumMaximumProperty(BigDecimal numberMinimumMaximumProperty) {
+        this.numberMinimumMaximumProperty = numberMinimumMaximumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberMinimumMaximumProperty")
+    @Valid @DecimalRange(min = "3.2", max = "7.5") 
+    public BigDecimal getNumberMinimumMaximumProperty() {
+        return numberMinimumMaximumProperty;
+    }
+
+    @JsonProperty("numberMinimumMaximumProperty")
+    public void setNumberMinimumMaximumProperty(BigDecimal numberMinimumMaximumProperty) {
+        this.numberMinimumMaximumProperty = numberMinimumMaximumProperty;
+    }
+
+    /**
+     * minimum: 3.2
+     * maximum: 7.5
+     */
+    public ValidationRequest numberRequiredMinimumMaximumProperty(BigDecimal numberRequiredMinimumMaximumProperty) {
+        this.numberRequiredMinimumMaximumProperty = numberRequiredMinimumMaximumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberRequiredMinimumMaximumProperty")
+    @Required @Valid @DecimalRange(min = "3.2", max = "7.5") 
+    public BigDecimal getNumberRequiredMinimumMaximumProperty() {
+        return numberRequiredMinimumMaximumProperty;
+    }
+
+    @JsonProperty("numberRequiredMinimumMaximumProperty")
+    public void setNumberRequiredMinimumMaximumProperty(BigDecimal numberRequiredMinimumMaximumProperty) {
+        this.numberRequiredMinimumMaximumProperty = numberRequiredMinimumMaximumProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest numberFloatPlainProperty(Float numberFloatPlainProperty) {
+        this.numberFloatPlainProperty = numberFloatPlainProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberFloatPlainProperty")
+    
+    public Float getNumberFloatPlainProperty() {
+        return numberFloatPlainProperty;
+    }
+
+    @JsonProperty("numberFloatPlainProperty")
+    public void setNumberFloatPlainProperty(Float numberFloatPlainProperty) {
+        this.numberFloatPlainProperty = numberFloatPlainProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest numberFloatRequiredProperty(Float numberFloatRequiredProperty) {
+        this.numberFloatRequiredProperty = numberFloatRequiredProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberFloatRequiredProperty")
+    @Required 
+    public Float getNumberFloatRequiredProperty() {
+        return numberFloatRequiredProperty;
+    }
+
+    @JsonProperty("numberFloatRequiredProperty")
+    public void setNumberFloatRequiredProperty(Float numberFloatRequiredProperty) {
+        this.numberFloatRequiredProperty = numberFloatRequiredProperty;
+    }
+
+    /**
+     * minimum: 3.2
+     */
+    public ValidationRequest numberFloatMinimumProperty(Float numberFloatMinimumProperty) {
+        this.numberFloatMinimumProperty = numberFloatMinimumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberFloatMinimumProperty")
+    @DecimalRange(min = "3.2") 
+    public Float getNumberFloatMinimumProperty() {
+        return numberFloatMinimumProperty;
+    }
+
+    @JsonProperty("numberFloatMinimumProperty")
+    public void setNumberFloatMinimumProperty(Float numberFloatMinimumProperty) {
+        this.numberFloatMinimumProperty = numberFloatMinimumProperty;
+    }
+
+    /**
+     * maximum: 7.5
+     */
+    public ValidationRequest numberFloatMaximumProperty(Float numberFloatMaximumProperty) {
+        this.numberFloatMaximumProperty = numberFloatMaximumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberFloatMaximumProperty")
+    @DecimalRange(max = "7.5") 
+    public Float getNumberFloatMaximumProperty() {
+        return numberFloatMaximumProperty;
+    }
+
+    @JsonProperty("numberFloatMaximumProperty")
+    public void setNumberFloatMaximumProperty(Float numberFloatMaximumProperty) {
+        this.numberFloatMaximumProperty = numberFloatMaximumProperty;
+    }
+
+    /**
+     * minimum: 3.2
+     * maximum: 7.5
+     */
+    public ValidationRequest numberFloatMinimumMaximumProperty(Float numberFloatMinimumMaximumProperty) {
+        this.numberFloatMinimumMaximumProperty = numberFloatMinimumMaximumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberFloatMinimumMaximumProperty")
+    @DecimalRange(min = "3.2", max = "7.5") 
+    public Float getNumberFloatMinimumMaximumProperty() {
+        return numberFloatMinimumMaximumProperty;
+    }
+
+    @JsonProperty("numberFloatMinimumMaximumProperty")
+    public void setNumberFloatMinimumMaximumProperty(Float numberFloatMinimumMaximumProperty) {
+        this.numberFloatMinimumMaximumProperty = numberFloatMinimumMaximumProperty;
+    }
+
+    /**
+     * minimum: 3.2
+     * maximum: 7.5
+     */
+    public ValidationRequest numberFloatRequiredMinimumMaximumProperty(Float numberFloatRequiredMinimumMaximumProperty) {
+        this.numberFloatRequiredMinimumMaximumProperty = numberFloatRequiredMinimumMaximumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberFloatRequiredMinimumMaximumProperty")
+    @Required @DecimalRange(min = "3.2", max = "7.5") 
+    public Float getNumberFloatRequiredMinimumMaximumProperty() {
+        return numberFloatRequiredMinimumMaximumProperty;
+    }
+
+    @JsonProperty("numberFloatRequiredMinimumMaximumProperty")
+    public void setNumberFloatRequiredMinimumMaximumProperty(Float numberFloatRequiredMinimumMaximumProperty) {
+        this.numberFloatRequiredMinimumMaximumProperty = numberFloatRequiredMinimumMaximumProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest numberDoublePlainProperty(Double numberDoublePlainProperty) {
+        this.numberDoublePlainProperty = numberDoublePlainProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberDoublePlainProperty")
+    
+    public Double getNumberDoublePlainProperty() {
+        return numberDoublePlainProperty;
+    }
+
+    @JsonProperty("numberDoublePlainProperty")
+    public void setNumberDoublePlainProperty(Double numberDoublePlainProperty) {
+        this.numberDoublePlainProperty = numberDoublePlainProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest numberDoubleRequiredProperty(Double numberDoubleRequiredProperty) {
+        this.numberDoubleRequiredProperty = numberDoubleRequiredProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberDoubleRequiredProperty")
+    @Required 
+    public Double getNumberDoubleRequiredProperty() {
+        return numberDoubleRequiredProperty;
+    }
+
+    @JsonProperty("numberDoubleRequiredProperty")
+    public void setNumberDoubleRequiredProperty(Double numberDoubleRequiredProperty) {
+        this.numberDoubleRequiredProperty = numberDoubleRequiredProperty;
+    }
+
+    /**
+     * minimum: 3.2
+     */
+    public ValidationRequest numberDoubleMinimumProperty(Double numberDoubleMinimumProperty) {
+        this.numberDoubleMinimumProperty = numberDoubleMinimumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberDoubleMinimumProperty")
+    @DecimalRange(min = "3.2") 
+    public Double getNumberDoubleMinimumProperty() {
+        return numberDoubleMinimumProperty;
+    }
+
+    @JsonProperty("numberDoubleMinimumProperty")
+    public void setNumberDoubleMinimumProperty(Double numberDoubleMinimumProperty) {
+        this.numberDoubleMinimumProperty = numberDoubleMinimumProperty;
+    }
+
+    /**
+     * maximum: 7.5
+     */
+    public ValidationRequest numberDoubleMaximumProperty(Double numberDoubleMaximumProperty) {
+        this.numberDoubleMaximumProperty = numberDoubleMaximumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberDoubleMaximumProperty")
+    @DecimalRange(max = "7.5") 
+    public Double getNumberDoubleMaximumProperty() {
+        return numberDoubleMaximumProperty;
+    }
+
+    @JsonProperty("numberDoubleMaximumProperty")
+    public void setNumberDoubleMaximumProperty(Double numberDoubleMaximumProperty) {
+        this.numberDoubleMaximumProperty = numberDoubleMaximumProperty;
+    }
+
+    /**
+     * minimum: 3.2
+     * maximum: 7.5
+     */
+    public ValidationRequest numberDoubleMinimumMaximumProperty(Double numberDoubleMinimumMaximumProperty) {
+        this.numberDoubleMinimumMaximumProperty = numberDoubleMinimumMaximumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberDoubleMinimumMaximumProperty")
+    @DecimalRange(min = "3.2", max = "7.5") 
+    public Double getNumberDoubleMinimumMaximumProperty() {
+        return numberDoubleMinimumMaximumProperty;
+    }
+
+    @JsonProperty("numberDoubleMinimumMaximumProperty")
+    public void setNumberDoubleMinimumMaximumProperty(Double numberDoubleMinimumMaximumProperty) {
+        this.numberDoubleMinimumMaximumProperty = numberDoubleMinimumMaximumProperty;
+    }
+
+    /**
+     * minimum: 3.2
+     * maximum: 7.5
+     */
+    public ValidationRequest numberDoubleRequiredMinimumMaximumProperty(Double numberDoubleRequiredMinimumMaximumProperty) {
+        this.numberDoubleRequiredMinimumMaximumProperty = numberDoubleRequiredMinimumMaximumProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("numberDoubleRequiredMinimumMaximumProperty")
+    @Required @DecimalRange(min = "3.2", max = "7.5") 
+    public Double getNumberDoubleRequiredMinimumMaximumProperty() {
+        return numberDoubleRequiredMinimumMaximumProperty;
+    }
+
+    @JsonProperty("numberDoubleRequiredMinimumMaximumProperty")
+    public void setNumberDoubleRequiredMinimumMaximumProperty(Double numberDoubleRequiredMinimumMaximumProperty) {
+        this.numberDoubleRequiredMinimumMaximumProperty = numberDoubleRequiredMinimumMaximumProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest booleanPlainProperty(Boolean booleanPlainProperty) {
+        this.booleanPlainProperty = booleanPlainProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("booleanPlainProperty")
+    
+    public Boolean getBooleanPlainProperty() {
+        return booleanPlainProperty;
+    }
+
+    @JsonProperty("booleanPlainProperty")
+    public void setBooleanPlainProperty(Boolean booleanPlainProperty) {
+        this.booleanPlainProperty = booleanPlainProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest booleanRequiredProperty(Boolean booleanRequiredProperty) {
+        this.booleanRequiredProperty = booleanRequiredProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("booleanRequiredProperty")
+    @Required 
+    public Boolean getBooleanRequiredProperty() {
+        return booleanRequiredProperty;
+    }
+
+    @JsonProperty("booleanRequiredProperty")
+    public void setBooleanRequiredProperty(Boolean booleanRequiredProperty) {
+        this.booleanRequiredProperty = booleanRequiredProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringPlainProperty(String stringPlainProperty) {
+        this.stringPlainProperty = stringPlainProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringPlainProperty")
+    
+    public String getStringPlainProperty() {
+        return stringPlainProperty;
+    }
+
+    @JsonProperty("stringPlainProperty")
+    public void setStringPlainProperty(String stringPlainProperty) {
+        this.stringPlainProperty = stringPlainProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringRequiredProperty(String stringRequiredProperty) {
+        this.stringRequiredProperty = stringRequiredProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringRequiredProperty")
+    @Required 
+    public String getStringRequiredProperty() {
+        return stringRequiredProperty;
+    }
+
+    @JsonProperty("stringRequiredProperty")
+    public void setStringRequiredProperty(String stringRequiredProperty) {
+        this.stringRequiredProperty = stringRequiredProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringMinLengthProperty(String stringMinLengthProperty) {
+        this.stringMinLengthProperty = stringMinLengthProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringMinLengthProperty")
+    @Length(min = 3) 
+    public String getStringMinLengthProperty() {
+        return stringMinLengthProperty;
+    }
+
+    @JsonProperty("stringMinLengthProperty")
+    public void setStringMinLengthProperty(String stringMinLengthProperty) {
+        this.stringMinLengthProperty = stringMinLengthProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringMaxLengthProperty(String stringMaxLengthProperty) {
+        this.stringMaxLengthProperty = stringMaxLengthProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringMaxLengthProperty")
+    @Length(max = 7) 
+    public String getStringMaxLengthProperty() {
+        return stringMaxLengthProperty;
+    }
+
+    @JsonProperty("stringMaxLengthProperty")
+    public void setStringMaxLengthProperty(String stringMaxLengthProperty) {
+        this.stringMaxLengthProperty = stringMaxLengthProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringMinLengthMaxLengthProperty(String stringMinLengthMaxLengthProperty) {
+        this.stringMinLengthMaxLengthProperty = stringMinLengthMaxLengthProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringMinLengthMaxLengthProperty")
+    @Length(min = 3, max = 7) 
+    public String getStringMinLengthMaxLengthProperty() {
+        return stringMinLengthMaxLengthProperty;
+    }
+
+    @JsonProperty("stringMinLengthMaxLengthProperty")
+    public void setStringMinLengthMaxLengthProperty(String stringMinLengthMaxLengthProperty) {
+        this.stringMinLengthMaxLengthProperty = stringMinLengthMaxLengthProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringPatternProperty(String stringPatternProperty) {
+        this.stringPatternProperty = stringPatternProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringPatternProperty")
+    @Pattern(regexp = "[a-z]+") 
+    public String getStringPatternProperty() {
+        return stringPatternProperty;
+    }
+
+    @JsonProperty("stringPatternProperty")
+    public void setStringPatternProperty(String stringPatternProperty) {
+        this.stringPatternProperty = stringPatternProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringRequiredMinLengthMaxLengthPatternProperty(String stringRequiredMinLengthMaxLengthPatternProperty) {
+        this.stringRequiredMinLengthMaxLengthPatternProperty = stringRequiredMinLengthMaxLengthPatternProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringRequiredMinLengthMaxLengthPatternProperty")
+    @Required @Pattern(regexp = "[a-z]+") @Length(min = 3, max = 7) 
+    public String getStringRequiredMinLengthMaxLengthPatternProperty() {
+        return stringRequiredMinLengthMaxLengthPatternProperty;
+    }
+
+    @JsonProperty("stringRequiredMinLengthMaxLengthPatternProperty")
+    public void setStringRequiredMinLengthMaxLengthPatternProperty(String stringRequiredMinLengthMaxLengthPatternProperty) {
+        this.stringRequiredMinLengthMaxLengthPatternProperty = stringRequiredMinLengthMaxLengthPatternProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringByteArrayProperty(byte[] stringByteArrayProperty) {
+        this.stringByteArrayProperty = stringByteArrayProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringByteArrayProperty")
+    @Required 
+    public byte[] getStringByteArrayProperty() {
+        return stringByteArrayProperty;
+    }
+
+    @JsonProperty("stringByteArrayProperty")
+    public void setStringByteArrayProperty(byte[] stringByteArrayProperty) {
+        this.stringByteArrayProperty = stringByteArrayProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringByteArrayMinLengthProperty(byte[] stringByteArrayMinLengthProperty) {
+        this.stringByteArrayMinLengthProperty = stringByteArrayMinLengthProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringByteArrayMinLengthProperty")
+    @Size(min = 3) 
+    public byte[] getStringByteArrayMinLengthProperty() {
+        return stringByteArrayMinLengthProperty;
+    }
+
+    @JsonProperty("stringByteArrayMinLengthProperty")
+    public void setStringByteArrayMinLengthProperty(byte[] stringByteArrayMinLengthProperty) {
+        this.stringByteArrayMinLengthProperty = stringByteArrayMinLengthProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringByteArrayMaxLengthProperty(byte[] stringByteArrayMaxLengthProperty) {
+        this.stringByteArrayMaxLengthProperty = stringByteArrayMaxLengthProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringByteArrayMaxLengthProperty")
+    @Size(max = 7) 
+    public byte[] getStringByteArrayMaxLengthProperty() {
+        return stringByteArrayMaxLengthProperty;
+    }
+
+    @JsonProperty("stringByteArrayMaxLengthProperty")
+    public void setStringByteArrayMaxLengthProperty(byte[] stringByteArrayMaxLengthProperty) {
+        this.stringByteArrayMaxLengthProperty = stringByteArrayMaxLengthProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringByteArrayMinLengthMaxLengthProperty(byte[] stringByteArrayMinLengthMaxLengthProperty) {
+        this.stringByteArrayMinLengthMaxLengthProperty = stringByteArrayMinLengthMaxLengthProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringByteArrayMinLengthMaxLengthProperty")
+    @Size(min = 3, max = 7) 
+    public byte[] getStringByteArrayMinLengthMaxLengthProperty() {
+        return stringByteArrayMinLengthMaxLengthProperty;
+    }
+
+    @JsonProperty("stringByteArrayMinLengthMaxLengthProperty")
+    public void setStringByteArrayMinLengthMaxLengthProperty(byte[] stringByteArrayMinLengthMaxLengthProperty) {
+        this.stringByteArrayMinLengthMaxLengthProperty = stringByteArrayMinLengthMaxLengthProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringByteArrayRequiredMinLengthMaxLengthProperty(byte[] stringByteArrayRequiredMinLengthMaxLengthProperty) {
+        this.stringByteArrayRequiredMinLengthMaxLengthProperty = stringByteArrayRequiredMinLengthMaxLengthProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringByteArrayRequiredMinLengthMaxLengthProperty")
+    @Required @Size(min = 3, max = 7) 
+    public byte[] getStringByteArrayRequiredMinLengthMaxLengthProperty() {
+        return stringByteArrayRequiredMinLengthMaxLengthProperty;
+    }
+
+    @JsonProperty("stringByteArrayRequiredMinLengthMaxLengthProperty")
+    public void setStringByteArrayRequiredMinLengthMaxLengthProperty(byte[] stringByteArrayRequiredMinLengthMaxLengthProperty) {
+        this.stringByteArrayRequiredMinLengthMaxLengthProperty = stringByteArrayRequiredMinLengthMaxLengthProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringDatePlainProperty(LocalDate stringDatePlainProperty) {
+        this.stringDatePlainProperty = stringDatePlainProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringDatePlainProperty")
+    
+    public LocalDate getStringDatePlainProperty() {
+        return stringDatePlainProperty;
+    }
+
+    @JsonProperty("stringDatePlainProperty")
+    public void setStringDatePlainProperty(LocalDate stringDatePlainProperty) {
+        this.stringDatePlainProperty = stringDatePlainProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringDateRequiredProperty(LocalDate stringDateRequiredProperty) {
+        this.stringDateRequiredProperty = stringDateRequiredProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringDateRequiredProperty")
+    @Required 
+    public LocalDate getStringDateRequiredProperty() {
+        return stringDateRequiredProperty;
+    }
+
+    @JsonProperty("stringDateRequiredProperty")
+    public void setStringDateRequiredProperty(LocalDate stringDateRequiredProperty) {
+        this.stringDateRequiredProperty = stringDateRequiredProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringDateTimePlainProperty(OffsetDateTime stringDateTimePlainProperty) {
+        this.stringDateTimePlainProperty = stringDateTimePlainProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringDateTimePlainProperty")
+    
+    public OffsetDateTime getStringDateTimePlainProperty() {
+        return stringDateTimePlainProperty;
+    }
+
+    @JsonProperty("stringDateTimePlainProperty")
+    public void setStringDateTimePlainProperty(OffsetDateTime stringDateTimePlainProperty) {
+        this.stringDateTimePlainProperty = stringDateTimePlainProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringDateTimeRequiredProperty(OffsetDateTime stringDateTimeRequiredProperty) {
+        this.stringDateTimeRequiredProperty = stringDateTimeRequiredProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringDateTimeRequiredProperty")
+    @Required 
+    public OffsetDateTime getStringDateTimeRequiredProperty() {
+        return stringDateTimeRequiredProperty;
+    }
+
+    @JsonProperty("stringDateTimeRequiredProperty")
+    public void setStringDateTimeRequiredProperty(OffsetDateTime stringDateTimeRequiredProperty) {
+        this.stringDateTimeRequiredProperty = stringDateTimeRequiredProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringPasswordPlainProperty(String stringPasswordPlainProperty) {
+        this.stringPasswordPlainProperty = stringPasswordPlainProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringPasswordPlainProperty")
+    
+    public String getStringPasswordPlainProperty() {
+        return stringPasswordPlainProperty;
+    }
+
+    @JsonProperty("stringPasswordPlainProperty")
+    public void setStringPasswordPlainProperty(String stringPasswordPlainProperty) {
+        this.stringPasswordPlainProperty = stringPasswordPlainProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringPasswordRequiredProperty(String stringPasswordRequiredProperty) {
+        this.stringPasswordRequiredProperty = stringPasswordRequiredProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringPasswordRequiredProperty")
+    @Required 
+    public String getStringPasswordRequiredProperty() {
+        return stringPasswordRequiredProperty;
+    }
+
+    @JsonProperty("stringPasswordRequiredProperty")
+    public void setStringPasswordRequiredProperty(String stringPasswordRequiredProperty) {
+        this.stringPasswordRequiredProperty = stringPasswordRequiredProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringPasswordMinLengthProperty(String stringPasswordMinLengthProperty) {
+        this.stringPasswordMinLengthProperty = stringPasswordMinLengthProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringPasswordMinLengthProperty")
+    @Length(min = 3) 
+    public String getStringPasswordMinLengthProperty() {
+        return stringPasswordMinLengthProperty;
+    }
+
+    @JsonProperty("stringPasswordMinLengthProperty")
+    public void setStringPasswordMinLengthProperty(String stringPasswordMinLengthProperty) {
+        this.stringPasswordMinLengthProperty = stringPasswordMinLengthProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringPasswordMaxLengthProperty(String stringPasswordMaxLengthProperty) {
+        this.stringPasswordMaxLengthProperty = stringPasswordMaxLengthProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringPasswordMaxLengthProperty")
+    @Length(max = 7) 
+    public String getStringPasswordMaxLengthProperty() {
+        return stringPasswordMaxLengthProperty;
+    }
+
+    @JsonProperty("stringPasswordMaxLengthProperty")
+    public void setStringPasswordMaxLengthProperty(String stringPasswordMaxLengthProperty) {
+        this.stringPasswordMaxLengthProperty = stringPasswordMaxLengthProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringPasswordMinLengthMaxLengthProperty(String stringPasswordMinLengthMaxLengthProperty) {
+        this.stringPasswordMinLengthMaxLengthProperty = stringPasswordMinLengthMaxLengthProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringPasswordMinLengthMaxLengthProperty")
+    @Length(min = 3, max = 7) 
+    public String getStringPasswordMinLengthMaxLengthProperty() {
+        return stringPasswordMinLengthMaxLengthProperty;
+    }
+
+    @JsonProperty("stringPasswordMinLengthMaxLengthProperty")
+    public void setStringPasswordMinLengthMaxLengthProperty(String stringPasswordMinLengthMaxLengthProperty) {
+        this.stringPasswordMinLengthMaxLengthProperty = stringPasswordMinLengthMaxLengthProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringPasswordPatternProperty(String stringPasswordPatternProperty) {
+        this.stringPasswordPatternProperty = stringPasswordPatternProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringPasswordPatternProperty")
+    @Pattern(regexp = "[a-z]+") 
+    public String getStringPasswordPatternProperty() {
+        return stringPasswordPatternProperty;
+    }
+
+    @JsonProperty("stringPasswordPatternProperty")
+    public void setStringPasswordPatternProperty(String stringPasswordPatternProperty) {
+        this.stringPasswordPatternProperty = stringPasswordPatternProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringPasswordRequiredMinLengthMaxLengthPatternProperty(String stringPasswordRequiredMinLengthMaxLengthPatternProperty) {
+        this.stringPasswordRequiredMinLengthMaxLengthPatternProperty = stringPasswordRequiredMinLengthMaxLengthPatternProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringPasswordRequiredMinLengthMaxLengthPatternProperty")
+    @Required @Pattern(regexp = "[a-z]+") @Length(min = 3, max = 7) 
+    public String getStringPasswordRequiredMinLengthMaxLengthPatternProperty() {
+        return stringPasswordRequiredMinLengthMaxLengthPatternProperty;
+    }
+
+    @JsonProperty("stringPasswordRequiredMinLengthMaxLengthPatternProperty")
+    public void setStringPasswordRequiredMinLengthMaxLengthPatternProperty(String stringPasswordRequiredMinLengthMaxLengthPatternProperty) {
+        this.stringPasswordRequiredMinLengthMaxLengthPatternProperty = stringPasswordRequiredMinLengthMaxLengthPatternProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringNumberPlainProperty(BigDecimal stringNumberPlainProperty) {
+        this.stringNumberPlainProperty = stringNumberPlainProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringNumberPlainProperty")
+    @Valid 
+    public BigDecimal getStringNumberPlainProperty() {
+        return stringNumberPlainProperty;
+    }
+
+    @JsonProperty("stringNumberPlainProperty")
+    public void setStringNumberPlainProperty(BigDecimal stringNumberPlainProperty) {
+        this.stringNumberPlainProperty = stringNumberPlainProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringNumberRequiredProperty(BigDecimal stringNumberRequiredProperty) {
+        this.stringNumberRequiredProperty = stringNumberRequiredProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringNumberRequiredProperty")
+    @Required @Valid 
+    public BigDecimal getStringNumberRequiredProperty() {
+        return stringNumberRequiredProperty;
+    }
+
+    @JsonProperty("stringNumberRequiredProperty")
+    public void setStringNumberRequiredProperty(BigDecimal stringNumberRequiredProperty) {
+        this.stringNumberRequiredProperty = stringNumberRequiredProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringUriPlainProperty(URI stringUriPlainProperty) {
+        this.stringUriPlainProperty = stringUriPlainProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringUriPlainProperty")
+    
+    public URI getStringUriPlainProperty() {
+        return stringUriPlainProperty;
+    }
+
+    @JsonProperty("stringUriPlainProperty")
+    public void setStringUriPlainProperty(URI stringUriPlainProperty) {
+        this.stringUriPlainProperty = stringUriPlainProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringUriRequiredProperty(URI stringUriRequiredProperty) {
+        this.stringUriRequiredProperty = stringUriRequiredProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringUriRequiredProperty")
+    @Required 
+    public URI getStringUriRequiredProperty() {
+        return stringUriRequiredProperty;
+    }
+
+    @JsonProperty("stringUriRequiredProperty")
+    public void setStringUriRequiredProperty(URI stringUriRequiredProperty) {
+        this.stringUriRequiredProperty = stringUriRequiredProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringUuidPlainProperty(UUID stringUuidPlainProperty) {
+        this.stringUuidPlainProperty = stringUuidPlainProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringUuidPlainProperty")
+    
+    public UUID getStringUuidPlainProperty() {
+        return stringUuidPlainProperty;
+    }
+
+    @JsonProperty("stringUuidPlainProperty")
+    public void setStringUuidPlainProperty(UUID stringUuidPlainProperty) {
+        this.stringUuidPlainProperty = stringUuidPlainProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringUuidRequiredProperty(UUID stringUuidRequiredProperty) {
+        this.stringUuidRequiredProperty = stringUuidRequiredProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringUuidRequiredProperty")
+    @Required 
+    public UUID getStringUuidRequiredProperty() {
+        return stringUuidRequiredProperty;
+    }
+
+    @JsonProperty("stringUuidRequiredProperty")
+    public void setStringUuidRequiredProperty(UUID stringUuidRequiredProperty) {
+        this.stringUuidRequiredProperty = stringUuidRequiredProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringRegexPlainProperty(String stringRegexPlainProperty) {
+        this.stringRegexPlainProperty = stringRegexPlainProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringRegexPlainProperty")
+    
+    public String getStringRegexPlainProperty() {
+        return stringRegexPlainProperty;
+    }
+
+    @JsonProperty("stringRegexPlainProperty")
+    public void setStringRegexPlainProperty(String stringRegexPlainProperty) {
+        this.stringRegexPlainProperty = stringRegexPlainProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringRegexRequiredProperty(String stringRegexRequiredProperty) {
+        this.stringRegexRequiredProperty = stringRegexRequiredProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringRegexRequiredProperty")
+    @Required @Pattern(regexp = "[a-z]+") 
+    public String getStringRegexRequiredProperty() {
+        return stringRegexRequiredProperty;
+    }
+
+    @JsonProperty("stringRegexRequiredProperty")
+    public void setStringRegexRequiredProperty(String stringRegexRequiredProperty) {
+        this.stringRegexRequiredProperty = stringRegexRequiredProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringRegexMinLengthProperty(String stringRegexMinLengthProperty) {
+        this.stringRegexMinLengthProperty = stringRegexMinLengthProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringRegexMinLengthProperty")
+    @Pattern(regexp = "[a-z]+") @Length(min = 3) 
+    public String getStringRegexMinLengthProperty() {
+        return stringRegexMinLengthProperty;
+    }
+
+    @JsonProperty("stringRegexMinLengthProperty")
+    public void setStringRegexMinLengthProperty(String stringRegexMinLengthProperty) {
+        this.stringRegexMinLengthProperty = stringRegexMinLengthProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringRegexMaxLengthProperty(String stringRegexMaxLengthProperty) {
+        this.stringRegexMaxLengthProperty = stringRegexMaxLengthProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringRegexMaxLengthProperty")
+    @Pattern(regexp = "[a-z]+") @Length(max = 7) 
+    public String getStringRegexMaxLengthProperty() {
+        return stringRegexMaxLengthProperty;
+    }
+
+    @JsonProperty("stringRegexMaxLengthProperty")
+    public void setStringRegexMaxLengthProperty(String stringRegexMaxLengthProperty) {
+        this.stringRegexMaxLengthProperty = stringRegexMaxLengthProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringRegexMinLengthMaxLengthProperty(String stringRegexMinLengthMaxLengthProperty) {
+        this.stringRegexMinLengthMaxLengthProperty = stringRegexMinLengthMaxLengthProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringRegexMinLengthMaxLengthProperty")
+    @Pattern(regexp = "[a-z]+") @Length(min = 3, max = 7) 
+    public String getStringRegexMinLengthMaxLengthProperty() {
+        return stringRegexMinLengthMaxLengthProperty;
+    }
+
+    @JsonProperty("stringRegexMinLengthMaxLengthProperty")
+    public void setStringRegexMinLengthMaxLengthProperty(String stringRegexMinLengthMaxLengthProperty) {
+        this.stringRegexMinLengthMaxLengthProperty = stringRegexMinLengthMaxLengthProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest stringRegexRequiredMinLengthMaxLengthProperty(String stringRegexRequiredMinLengthMaxLengthProperty) {
+        this.stringRegexRequiredMinLengthMaxLengthProperty = stringRegexRequiredMinLengthMaxLengthProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("stringRegexRequiredMinLengthMaxLengthProperty")
+    @Required @Pattern(regexp = "[a-z]+") @Length(min = 3, max = 7) 
+    public String getStringRegexRequiredMinLengthMaxLengthProperty() {
+        return stringRegexRequiredMinLengthMaxLengthProperty;
+    }
+
+    @JsonProperty("stringRegexRequiredMinLengthMaxLengthProperty")
+    public void setStringRegexRequiredMinLengthMaxLengthProperty(String stringRegexRequiredMinLengthMaxLengthProperty) {
+        this.stringRegexRequiredMinLengthMaxLengthProperty = stringRegexRequiredMinLengthMaxLengthProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest arrayStringPlainProperty(List<String> arrayStringPlainProperty) {
+        this.arrayStringPlainProperty = arrayStringPlainProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayStringPlainProperty")
+    
+    public List<String> getArrayStringPlainProperty() {
+        return arrayStringPlainProperty;
+    }
+
+    @JsonProperty("arrayStringPlainProperty")
+    public void setArrayStringPlainProperty(List<String> arrayStringPlainProperty) {
+        this.arrayStringPlainProperty = arrayStringPlainProperty;
+    }
+
+    public ValidationRequest addArrayStringPlainPropertyItem(String arrayStringPlainPropertyItem) {
+        if (this.arrayStringPlainProperty == null) {
+            this.arrayStringPlainProperty = new ArrayList<>();
+        }
+
+        this.arrayStringPlainProperty.add(arrayStringPlainPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayStringPlainPropertyItem(String arrayStringPlainPropertyItem) {
+        if (arrayStringPlainPropertyItem != null && this.arrayStringPlainProperty != null) {
+            this.arrayStringPlainProperty.remove(arrayStringPlainPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest arrayStringRequiredProperty(List<String> arrayStringRequiredProperty) {
+        this.arrayStringRequiredProperty = arrayStringRequiredProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayStringRequiredProperty")
+    @Required 
+    public List<String> getArrayStringRequiredProperty() {
+        return arrayStringRequiredProperty;
+    }
+
+    @JsonProperty("arrayStringRequiredProperty")
+    public void setArrayStringRequiredProperty(List<String> arrayStringRequiredProperty) {
+        this.arrayStringRequiredProperty = arrayStringRequiredProperty;
+    }
+
+    public ValidationRequest addArrayStringRequiredPropertyItem(String arrayStringRequiredPropertyItem) {
+        if (this.arrayStringRequiredProperty == null) {
+            this.arrayStringRequiredProperty = new ArrayList<>();
+        }
+
+        this.arrayStringRequiredProperty.add(arrayStringRequiredPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayStringRequiredPropertyItem(String arrayStringRequiredPropertyItem) {
+        if (arrayStringRequiredPropertyItem != null && this.arrayStringRequiredProperty != null) {
+            this.arrayStringRequiredProperty.remove(arrayStringRequiredPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest arrayStringMinItemsProperty(List<String> arrayStringMinItemsProperty) {
+        this.arrayStringMinItemsProperty = arrayStringMinItemsProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayStringMinItemsProperty")
+    @Size(min = 3) 
+    public List<String> getArrayStringMinItemsProperty() {
+        return arrayStringMinItemsProperty;
+    }
+
+    @JsonProperty("arrayStringMinItemsProperty")
+    public void setArrayStringMinItemsProperty(List<String> arrayStringMinItemsProperty) {
+        this.arrayStringMinItemsProperty = arrayStringMinItemsProperty;
+    }
+
+    public ValidationRequest addArrayStringMinItemsPropertyItem(String arrayStringMinItemsPropertyItem) {
+        if (this.arrayStringMinItemsProperty == null) {
+            this.arrayStringMinItemsProperty = new ArrayList<>();
+        }
+
+        this.arrayStringMinItemsProperty.add(arrayStringMinItemsPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayStringMinItemsPropertyItem(String arrayStringMinItemsPropertyItem) {
+        if (arrayStringMinItemsPropertyItem != null && this.arrayStringMinItemsProperty != null) {
+            this.arrayStringMinItemsProperty.remove(arrayStringMinItemsPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest arrayStringMaxItemsProperty(List<String> arrayStringMaxItemsProperty) {
+        this.arrayStringMaxItemsProperty = arrayStringMaxItemsProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayStringMaxItemsProperty")
+    @Size(max = 7) 
+    public List<String> getArrayStringMaxItemsProperty() {
+        return arrayStringMaxItemsProperty;
+    }
+
+    @JsonProperty("arrayStringMaxItemsProperty")
+    public void setArrayStringMaxItemsProperty(List<String> arrayStringMaxItemsProperty) {
+        this.arrayStringMaxItemsProperty = arrayStringMaxItemsProperty;
+    }
+
+    public ValidationRequest addArrayStringMaxItemsPropertyItem(String arrayStringMaxItemsPropertyItem) {
+        if (this.arrayStringMaxItemsProperty == null) {
+            this.arrayStringMaxItemsProperty = new ArrayList<>();
+        }
+
+        this.arrayStringMaxItemsProperty.add(arrayStringMaxItemsPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayStringMaxItemsPropertyItem(String arrayStringMaxItemsPropertyItem) {
+        if (arrayStringMaxItemsPropertyItem != null && this.arrayStringMaxItemsProperty != null) {
+            this.arrayStringMaxItemsProperty.remove(arrayStringMaxItemsPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest arrayStringMinItemsMaxItemsProperty(List<String> arrayStringMinItemsMaxItemsProperty) {
+        this.arrayStringMinItemsMaxItemsProperty = arrayStringMinItemsMaxItemsProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayStringMinItemsMaxItemsProperty")
+    @Size(min = 3, max = 7) 
+    public List<String> getArrayStringMinItemsMaxItemsProperty() {
+        return arrayStringMinItemsMaxItemsProperty;
+    }
+
+    @JsonProperty("arrayStringMinItemsMaxItemsProperty")
+    public void setArrayStringMinItemsMaxItemsProperty(List<String> arrayStringMinItemsMaxItemsProperty) {
+        this.arrayStringMinItemsMaxItemsProperty = arrayStringMinItemsMaxItemsProperty;
+    }
+
+    public ValidationRequest addArrayStringMinItemsMaxItemsPropertyItem(String arrayStringMinItemsMaxItemsPropertyItem) {
+        if (this.arrayStringMinItemsMaxItemsProperty == null) {
+            this.arrayStringMinItemsMaxItemsProperty = new ArrayList<>();
+        }
+
+        this.arrayStringMinItemsMaxItemsProperty.add(arrayStringMinItemsMaxItemsPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayStringMinItemsMaxItemsPropertyItem(String arrayStringMinItemsMaxItemsPropertyItem) {
+        if (arrayStringMinItemsMaxItemsPropertyItem != null && this.arrayStringMinItemsMaxItemsProperty != null) {
+            this.arrayStringMinItemsMaxItemsProperty.remove(arrayStringMinItemsMaxItemsPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest arrayStringRequiredMinItemsMaxItemsProperty(List<String> arrayStringRequiredMinItemsMaxItemsProperty) {
+        this.arrayStringRequiredMinItemsMaxItemsProperty = arrayStringRequiredMinItemsMaxItemsProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayStringRequiredMinItemsMaxItemsProperty")
+    @Required @Size(min = 3, max = 7) 
+    public List<String> getArrayStringRequiredMinItemsMaxItemsProperty() {
+        return arrayStringRequiredMinItemsMaxItemsProperty;
+    }
+
+    @JsonProperty("arrayStringRequiredMinItemsMaxItemsProperty")
+    public void setArrayStringRequiredMinItemsMaxItemsProperty(List<String> arrayStringRequiredMinItemsMaxItemsProperty) {
+        this.arrayStringRequiredMinItemsMaxItemsProperty = arrayStringRequiredMinItemsMaxItemsProperty;
+    }
+
+    public ValidationRequest addArrayStringRequiredMinItemsMaxItemsPropertyItem(String arrayStringRequiredMinItemsMaxItemsPropertyItem) {
+        if (this.arrayStringRequiredMinItemsMaxItemsProperty == null) {
+            this.arrayStringRequiredMinItemsMaxItemsProperty = new ArrayList<>();
+        }
+
+        this.arrayStringRequiredMinItemsMaxItemsProperty.add(arrayStringRequiredMinItemsMaxItemsPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayStringRequiredMinItemsMaxItemsPropertyItem(String arrayStringRequiredMinItemsMaxItemsPropertyItem) {
+        if (arrayStringRequiredMinItemsMaxItemsPropertyItem != null && this.arrayStringRequiredMinItemsMaxItemsProperty != null) {
+            this.arrayStringRequiredMinItemsMaxItemsProperty.remove(arrayStringRequiredMinItemsMaxItemsPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest arrayObjectPlainProperty(List<@Valid ValidationSubRequest> arrayObjectPlainProperty) {
+        this.arrayObjectPlainProperty = arrayObjectPlainProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayObjectPlainProperty")
+    @Valid 
+    public List<@Valid ValidationSubRequest> getArrayObjectPlainProperty() {
+        return arrayObjectPlainProperty;
+    }
+
+    @JsonProperty("arrayObjectPlainProperty")
+    public void setArrayObjectPlainProperty(List<@Valid ValidationSubRequest> arrayObjectPlainProperty) {
+        this.arrayObjectPlainProperty = arrayObjectPlainProperty;
+    }
+
+    public ValidationRequest addArrayObjectPlainPropertyItem(ValidationSubRequest arrayObjectPlainPropertyItem) {
+        if (this.arrayObjectPlainProperty == null) {
+            this.arrayObjectPlainProperty = new ArrayList<>();
+        }
+
+        this.arrayObjectPlainProperty.add(arrayObjectPlainPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayObjectPlainPropertyItem(ValidationSubRequest arrayObjectPlainPropertyItem) {
+        if (arrayObjectPlainPropertyItem != null && this.arrayObjectPlainProperty != null) {
+            this.arrayObjectPlainProperty.remove(arrayObjectPlainPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest arrayObjectRequiredProperty(List<@Valid ValidationSubRequest> arrayObjectRequiredProperty) {
+        this.arrayObjectRequiredProperty = arrayObjectRequiredProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayObjectRequiredProperty")
+    @Required @Valid 
+    public List<@Valid ValidationSubRequest> getArrayObjectRequiredProperty() {
+        return arrayObjectRequiredProperty;
+    }
+
+    @JsonProperty("arrayObjectRequiredProperty")
+    public void setArrayObjectRequiredProperty(List<@Valid ValidationSubRequest> arrayObjectRequiredProperty) {
+        this.arrayObjectRequiredProperty = arrayObjectRequiredProperty;
+    }
+
+    public ValidationRequest addArrayObjectRequiredPropertyItem(ValidationSubRequest arrayObjectRequiredPropertyItem) {
+        if (this.arrayObjectRequiredProperty == null) {
+            this.arrayObjectRequiredProperty = new ArrayList<>();
+        }
+
+        this.arrayObjectRequiredProperty.add(arrayObjectRequiredPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayObjectRequiredPropertyItem(ValidationSubRequest arrayObjectRequiredPropertyItem) {
+        if (arrayObjectRequiredPropertyItem != null && this.arrayObjectRequiredProperty != null) {
+            this.arrayObjectRequiredProperty.remove(arrayObjectRequiredPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest arrayObjectMinItemsProperty(List<@Valid ValidationSubRequest> arrayObjectMinItemsProperty) {
+        this.arrayObjectMinItemsProperty = arrayObjectMinItemsProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayObjectMinItemsProperty")
+    @Valid @Size(min = 3) 
+    public List<@Valid ValidationSubRequest> getArrayObjectMinItemsProperty() {
+        return arrayObjectMinItemsProperty;
+    }
+
+    @JsonProperty("arrayObjectMinItemsProperty")
+    public void setArrayObjectMinItemsProperty(List<@Valid ValidationSubRequest> arrayObjectMinItemsProperty) {
+        this.arrayObjectMinItemsProperty = arrayObjectMinItemsProperty;
+    }
+
+    public ValidationRequest addArrayObjectMinItemsPropertyItem(ValidationSubRequest arrayObjectMinItemsPropertyItem) {
+        if (this.arrayObjectMinItemsProperty == null) {
+            this.arrayObjectMinItemsProperty = new ArrayList<>();
+        }
+
+        this.arrayObjectMinItemsProperty.add(arrayObjectMinItemsPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayObjectMinItemsPropertyItem(ValidationSubRequest arrayObjectMinItemsPropertyItem) {
+        if (arrayObjectMinItemsPropertyItem != null && this.arrayObjectMinItemsProperty != null) {
+            this.arrayObjectMinItemsProperty.remove(arrayObjectMinItemsPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest arrayObjectMaxItemsProperty(List<@Valid ValidationSubRequest> arrayObjectMaxItemsProperty) {
+        this.arrayObjectMaxItemsProperty = arrayObjectMaxItemsProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayObjectMaxItemsProperty")
+    @Valid @Size(max = 7) 
+    public List<@Valid ValidationSubRequest> getArrayObjectMaxItemsProperty() {
+        return arrayObjectMaxItemsProperty;
+    }
+
+    @JsonProperty("arrayObjectMaxItemsProperty")
+    public void setArrayObjectMaxItemsProperty(List<@Valid ValidationSubRequest> arrayObjectMaxItemsProperty) {
+        this.arrayObjectMaxItemsProperty = arrayObjectMaxItemsProperty;
+    }
+
+    public ValidationRequest addArrayObjectMaxItemsPropertyItem(ValidationSubRequest arrayObjectMaxItemsPropertyItem) {
+        if (this.arrayObjectMaxItemsProperty == null) {
+            this.arrayObjectMaxItemsProperty = new ArrayList<>();
+        }
+
+        this.arrayObjectMaxItemsProperty.add(arrayObjectMaxItemsPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayObjectMaxItemsPropertyItem(ValidationSubRequest arrayObjectMaxItemsPropertyItem) {
+        if (arrayObjectMaxItemsPropertyItem != null && this.arrayObjectMaxItemsProperty != null) {
+            this.arrayObjectMaxItemsProperty.remove(arrayObjectMaxItemsPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest arrayObjectMinItemsMaxItemsProperty(List<@Valid ValidationSubRequest> arrayObjectMinItemsMaxItemsProperty) {
+        this.arrayObjectMinItemsMaxItemsProperty = arrayObjectMinItemsMaxItemsProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayObjectMinItemsMaxItemsProperty")
+    @Valid @Size(min = 3, max = 7) 
+    public List<@Valid ValidationSubRequest> getArrayObjectMinItemsMaxItemsProperty() {
+        return arrayObjectMinItemsMaxItemsProperty;
+    }
+
+    @JsonProperty("arrayObjectMinItemsMaxItemsProperty")
+    public void setArrayObjectMinItemsMaxItemsProperty(List<@Valid ValidationSubRequest> arrayObjectMinItemsMaxItemsProperty) {
+        this.arrayObjectMinItemsMaxItemsProperty = arrayObjectMinItemsMaxItemsProperty;
+    }
+
+    public ValidationRequest addArrayObjectMinItemsMaxItemsPropertyItem(ValidationSubRequest arrayObjectMinItemsMaxItemsPropertyItem) {
+        if (this.arrayObjectMinItemsMaxItemsProperty == null) {
+            this.arrayObjectMinItemsMaxItemsProperty = new ArrayList<>();
+        }
+
+        this.arrayObjectMinItemsMaxItemsProperty.add(arrayObjectMinItemsMaxItemsPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayObjectMinItemsMaxItemsPropertyItem(ValidationSubRequest arrayObjectMinItemsMaxItemsPropertyItem) {
+        if (arrayObjectMinItemsMaxItemsPropertyItem != null && this.arrayObjectMinItemsMaxItemsProperty != null) {
+            this.arrayObjectMinItemsMaxItemsProperty.remove(arrayObjectMinItemsMaxItemsPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest arrayObjectRequiredMinItemsMaxItemsProperty(List<@Valid ValidationSubRequest> arrayObjectRequiredMinItemsMaxItemsProperty) {
+        this.arrayObjectRequiredMinItemsMaxItemsProperty = arrayObjectRequiredMinItemsMaxItemsProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayObjectRequiredMinItemsMaxItemsProperty")
+    @Required @Valid @Size(min = 3, max = 7) 
+    public List<@Valid ValidationSubRequest> getArrayObjectRequiredMinItemsMaxItemsProperty() {
+        return arrayObjectRequiredMinItemsMaxItemsProperty;
+    }
+
+    @JsonProperty("arrayObjectRequiredMinItemsMaxItemsProperty")
+    public void setArrayObjectRequiredMinItemsMaxItemsProperty(List<@Valid ValidationSubRequest> arrayObjectRequiredMinItemsMaxItemsProperty) {
+        this.arrayObjectRequiredMinItemsMaxItemsProperty = arrayObjectRequiredMinItemsMaxItemsProperty;
+    }
+
+    public ValidationRequest addArrayObjectRequiredMinItemsMaxItemsPropertyItem(ValidationSubRequest arrayObjectRequiredMinItemsMaxItemsPropertyItem) {
+        if (this.arrayObjectRequiredMinItemsMaxItemsProperty == null) {
+            this.arrayObjectRequiredMinItemsMaxItemsProperty = new ArrayList<>();
+        }
+
+        this.arrayObjectRequiredMinItemsMaxItemsProperty.add(arrayObjectRequiredMinItemsMaxItemsPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayObjectRequiredMinItemsMaxItemsPropertyItem(ValidationSubRequest arrayObjectRequiredMinItemsMaxItemsPropertyItem) {
+        if (arrayObjectRequiredMinItemsMaxItemsPropertyItem != null && this.arrayObjectRequiredMinItemsMaxItemsProperty != null) {
+            this.arrayObjectRequiredMinItemsMaxItemsProperty.remove(arrayObjectRequiredMinItemsMaxItemsPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest arrayStringUniqueItemsPlainProperty(Set<String> arrayStringUniqueItemsPlainProperty) {
+        this.arrayStringUniqueItemsPlainProperty = arrayStringUniqueItemsPlainProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayStringUniqueItemsPlainProperty")
+    
+    public Set<String> getArrayStringUniqueItemsPlainProperty() {
+        return arrayStringUniqueItemsPlainProperty;
+    }
+
+    @JsonProperty("arrayStringUniqueItemsPlainProperty")
+    @JsonDeserialize(as = LinkedHashSet.class)
+    public void setArrayStringUniqueItemsPlainProperty(Set<String> arrayStringUniqueItemsPlainProperty) {
+        this.arrayStringUniqueItemsPlainProperty = arrayStringUniqueItemsPlainProperty;
+    }
+
+    public ValidationRequest addArrayStringUniqueItemsPlainPropertyItem(String arrayStringUniqueItemsPlainPropertyItem) {
+        if (this.arrayStringUniqueItemsPlainProperty == null) {
+            this.arrayStringUniqueItemsPlainProperty = new LinkedHashSet<>();
+        }
+
+        this.arrayStringUniqueItemsPlainProperty.add(arrayStringUniqueItemsPlainPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayStringUniqueItemsPlainPropertyItem(String arrayStringUniqueItemsPlainPropertyItem) {
+        if (arrayStringUniqueItemsPlainPropertyItem != null && this.arrayStringUniqueItemsPlainProperty != null) {
+            this.arrayStringUniqueItemsPlainProperty.remove(arrayStringUniqueItemsPlainPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest arrayStringUniqueItemsRequiredProperty(Set<String> arrayStringUniqueItemsRequiredProperty) {
+        this.arrayStringUniqueItemsRequiredProperty = arrayStringUniqueItemsRequiredProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayStringUniqueItemsRequiredProperty")
+    @Required 
+    public Set<String> getArrayStringUniqueItemsRequiredProperty() {
+        return arrayStringUniqueItemsRequiredProperty;
+    }
+
+    @JsonProperty("arrayStringUniqueItemsRequiredProperty")
+    @JsonDeserialize(as = LinkedHashSet.class)
+    public void setArrayStringUniqueItemsRequiredProperty(Set<String> arrayStringUniqueItemsRequiredProperty) {
+        this.arrayStringUniqueItemsRequiredProperty = arrayStringUniqueItemsRequiredProperty;
+    }
+
+    public ValidationRequest addArrayStringUniqueItemsRequiredPropertyItem(String arrayStringUniqueItemsRequiredPropertyItem) {
+        if (this.arrayStringUniqueItemsRequiredProperty == null) {
+            this.arrayStringUniqueItemsRequiredProperty = new LinkedHashSet<>();
+        }
+
+        this.arrayStringUniqueItemsRequiredProperty.add(arrayStringUniqueItemsRequiredPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayStringUniqueItemsRequiredPropertyItem(String arrayStringUniqueItemsRequiredPropertyItem) {
+        if (arrayStringUniqueItemsRequiredPropertyItem != null && this.arrayStringUniqueItemsRequiredProperty != null) {
+            this.arrayStringUniqueItemsRequiredProperty.remove(arrayStringUniqueItemsRequiredPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest arrayStringUniqueItemsMinItemsProperty(Set<String> arrayStringUniqueItemsMinItemsProperty) {
+        this.arrayStringUniqueItemsMinItemsProperty = arrayStringUniqueItemsMinItemsProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayStringUniqueItemsMinItemsProperty")
+    @Size(min = 3) 
+    public Set<String> getArrayStringUniqueItemsMinItemsProperty() {
+        return arrayStringUniqueItemsMinItemsProperty;
+    }
+
+    @JsonProperty("arrayStringUniqueItemsMinItemsProperty")
+    @JsonDeserialize(as = LinkedHashSet.class)
+    public void setArrayStringUniqueItemsMinItemsProperty(Set<String> arrayStringUniqueItemsMinItemsProperty) {
+        this.arrayStringUniqueItemsMinItemsProperty = arrayStringUniqueItemsMinItemsProperty;
+    }
+
+    public ValidationRequest addArrayStringUniqueItemsMinItemsPropertyItem(String arrayStringUniqueItemsMinItemsPropertyItem) {
+        if (this.arrayStringUniqueItemsMinItemsProperty == null) {
+            this.arrayStringUniqueItemsMinItemsProperty = new LinkedHashSet<>();
+        }
+
+        this.arrayStringUniqueItemsMinItemsProperty.add(arrayStringUniqueItemsMinItemsPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayStringUniqueItemsMinItemsPropertyItem(String arrayStringUniqueItemsMinItemsPropertyItem) {
+        if (arrayStringUniqueItemsMinItemsPropertyItem != null && this.arrayStringUniqueItemsMinItemsProperty != null) {
+            this.arrayStringUniqueItemsMinItemsProperty.remove(arrayStringUniqueItemsMinItemsPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest arrayStringUniqueItemsMaxItemsProperty(Set<String> arrayStringUniqueItemsMaxItemsProperty) {
+        this.arrayStringUniqueItemsMaxItemsProperty = arrayStringUniqueItemsMaxItemsProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayStringUniqueItemsMaxItemsProperty")
+    @Size(max = 7) 
+    public Set<String> getArrayStringUniqueItemsMaxItemsProperty() {
+        return arrayStringUniqueItemsMaxItemsProperty;
+    }
+
+    @JsonProperty("arrayStringUniqueItemsMaxItemsProperty")
+    @JsonDeserialize(as = LinkedHashSet.class)
+    public void setArrayStringUniqueItemsMaxItemsProperty(Set<String> arrayStringUniqueItemsMaxItemsProperty) {
+        this.arrayStringUniqueItemsMaxItemsProperty = arrayStringUniqueItemsMaxItemsProperty;
+    }
+
+    public ValidationRequest addArrayStringUniqueItemsMaxItemsPropertyItem(String arrayStringUniqueItemsMaxItemsPropertyItem) {
+        if (this.arrayStringUniqueItemsMaxItemsProperty == null) {
+            this.arrayStringUniqueItemsMaxItemsProperty = new LinkedHashSet<>();
+        }
+
+        this.arrayStringUniqueItemsMaxItemsProperty.add(arrayStringUniqueItemsMaxItemsPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayStringUniqueItemsMaxItemsPropertyItem(String arrayStringUniqueItemsMaxItemsPropertyItem) {
+        if (arrayStringUniqueItemsMaxItemsPropertyItem != null && this.arrayStringUniqueItemsMaxItemsProperty != null) {
+            this.arrayStringUniqueItemsMaxItemsProperty.remove(arrayStringUniqueItemsMaxItemsPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest arrayStringUniqueItemsMinItemsMaxItemsProperty(Set<String> arrayStringUniqueItemsMinItemsMaxItemsProperty) {
+        this.arrayStringUniqueItemsMinItemsMaxItemsProperty = arrayStringUniqueItemsMinItemsMaxItemsProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayStringUniqueItemsMinItemsMaxItemsProperty")
+    @Size(min = 3, max = 7) 
+    public Set<String> getArrayStringUniqueItemsMinItemsMaxItemsProperty() {
+        return arrayStringUniqueItemsMinItemsMaxItemsProperty;
+    }
+
+    @JsonProperty("arrayStringUniqueItemsMinItemsMaxItemsProperty")
+    @JsonDeserialize(as = LinkedHashSet.class)
+    public void setArrayStringUniqueItemsMinItemsMaxItemsProperty(Set<String> arrayStringUniqueItemsMinItemsMaxItemsProperty) {
+        this.arrayStringUniqueItemsMinItemsMaxItemsProperty = arrayStringUniqueItemsMinItemsMaxItemsProperty;
+    }
+
+    public ValidationRequest addArrayStringUniqueItemsMinItemsMaxItemsPropertyItem(String arrayStringUniqueItemsMinItemsMaxItemsPropertyItem) {
+        if (this.arrayStringUniqueItemsMinItemsMaxItemsProperty == null) {
+            this.arrayStringUniqueItemsMinItemsMaxItemsProperty = new LinkedHashSet<>();
+        }
+
+        this.arrayStringUniqueItemsMinItemsMaxItemsProperty.add(arrayStringUniqueItemsMinItemsMaxItemsPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayStringUniqueItemsMinItemsMaxItemsPropertyItem(String arrayStringUniqueItemsMinItemsMaxItemsPropertyItem) {
+        if (arrayStringUniqueItemsMinItemsMaxItemsPropertyItem != null && this.arrayStringUniqueItemsMinItemsMaxItemsProperty != null) {
+            this.arrayStringUniqueItemsMinItemsMaxItemsProperty.remove(arrayStringUniqueItemsMinItemsMaxItemsPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest arrayStringUniqueItemsRequiredMinItemsMaxItemsProperty(Set<String> arrayStringUniqueItemsRequiredMinItemsMaxItemsProperty) {
+        this.arrayStringUniqueItemsRequiredMinItemsMaxItemsProperty = arrayStringUniqueItemsRequiredMinItemsMaxItemsProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayStringUniqueItemsRequiredMinItemsMaxItemsProperty")
+    @Required @Size(min = 3, max = 7) 
+    public Set<String> getArrayStringUniqueItemsRequiredMinItemsMaxItemsProperty() {
+        return arrayStringUniqueItemsRequiredMinItemsMaxItemsProperty;
+    }
+
+    @JsonProperty("arrayStringUniqueItemsRequiredMinItemsMaxItemsProperty")
+    @JsonDeserialize(as = LinkedHashSet.class)
+    public void setArrayStringUniqueItemsRequiredMinItemsMaxItemsProperty(Set<String> arrayStringUniqueItemsRequiredMinItemsMaxItemsProperty) {
+        this.arrayStringUniqueItemsRequiredMinItemsMaxItemsProperty = arrayStringUniqueItemsRequiredMinItemsMaxItemsProperty;
+    }
+
+    public ValidationRequest addArrayStringUniqueItemsRequiredMinItemsMaxItemsPropertyItem(String arrayStringUniqueItemsRequiredMinItemsMaxItemsPropertyItem) {
+        if (this.arrayStringUniqueItemsRequiredMinItemsMaxItemsProperty == null) {
+            this.arrayStringUniqueItemsRequiredMinItemsMaxItemsProperty = new LinkedHashSet<>();
+        }
+
+        this.arrayStringUniqueItemsRequiredMinItemsMaxItemsProperty.add(arrayStringUniqueItemsRequiredMinItemsMaxItemsPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayStringUniqueItemsRequiredMinItemsMaxItemsPropertyItem(String arrayStringUniqueItemsRequiredMinItemsMaxItemsPropertyItem) {
+        if (arrayStringUniqueItemsRequiredMinItemsMaxItemsPropertyItem != null && this.arrayStringUniqueItemsRequiredMinItemsMaxItemsProperty != null) {
+            this.arrayStringUniqueItemsRequiredMinItemsMaxItemsProperty.remove(arrayStringUniqueItemsRequiredMinItemsMaxItemsPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest arrayObjectUniqueItemsPlainProperty(Set<@Valid ValidationSubRequest> arrayObjectUniqueItemsPlainProperty) {
+        this.arrayObjectUniqueItemsPlainProperty = arrayObjectUniqueItemsPlainProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayObjectUniqueItemsPlainProperty")
+    @Valid 
+    public Set<@Valid ValidationSubRequest> getArrayObjectUniqueItemsPlainProperty() {
+        return arrayObjectUniqueItemsPlainProperty;
+    }
+
+    @JsonProperty("arrayObjectUniqueItemsPlainProperty")
+    @JsonDeserialize(as = LinkedHashSet.class)
+    public void setArrayObjectUniqueItemsPlainProperty(Set<@Valid ValidationSubRequest> arrayObjectUniqueItemsPlainProperty) {
+        this.arrayObjectUniqueItemsPlainProperty = arrayObjectUniqueItemsPlainProperty;
+    }
+
+    public ValidationRequest addArrayObjectUniqueItemsPlainPropertyItem(ValidationSubRequest arrayObjectUniqueItemsPlainPropertyItem) {
+        if (this.arrayObjectUniqueItemsPlainProperty == null) {
+            this.arrayObjectUniqueItemsPlainProperty = new LinkedHashSet<>();
+        }
+
+        this.arrayObjectUniqueItemsPlainProperty.add(arrayObjectUniqueItemsPlainPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayObjectUniqueItemsPlainPropertyItem(ValidationSubRequest arrayObjectUniqueItemsPlainPropertyItem) {
+        if (arrayObjectUniqueItemsPlainPropertyItem != null && this.arrayObjectUniqueItemsPlainProperty != null) {
+            this.arrayObjectUniqueItemsPlainProperty.remove(arrayObjectUniqueItemsPlainPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest arrayObjectUniqueItemsRequiredProperty(Set<@Valid ValidationSubRequest> arrayObjectUniqueItemsRequiredProperty) {
+        this.arrayObjectUniqueItemsRequiredProperty = arrayObjectUniqueItemsRequiredProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayObjectUniqueItemsRequiredProperty")
+    @Required @Valid 
+    public Set<@Valid ValidationSubRequest> getArrayObjectUniqueItemsRequiredProperty() {
+        return arrayObjectUniqueItemsRequiredProperty;
+    }
+
+    @JsonProperty("arrayObjectUniqueItemsRequiredProperty")
+    @JsonDeserialize(as = LinkedHashSet.class)
+    public void setArrayObjectUniqueItemsRequiredProperty(Set<@Valid ValidationSubRequest> arrayObjectUniqueItemsRequiredProperty) {
+        this.arrayObjectUniqueItemsRequiredProperty = arrayObjectUniqueItemsRequiredProperty;
+    }
+
+    public ValidationRequest addArrayObjectUniqueItemsRequiredPropertyItem(ValidationSubRequest arrayObjectUniqueItemsRequiredPropertyItem) {
+        if (this.arrayObjectUniqueItemsRequiredProperty == null) {
+            this.arrayObjectUniqueItemsRequiredProperty = new LinkedHashSet<>();
+        }
+
+        this.arrayObjectUniqueItemsRequiredProperty.add(arrayObjectUniqueItemsRequiredPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayObjectUniqueItemsRequiredPropertyItem(ValidationSubRequest arrayObjectUniqueItemsRequiredPropertyItem) {
+        if (arrayObjectUniqueItemsRequiredPropertyItem != null && this.arrayObjectUniqueItemsRequiredProperty != null) {
+            this.arrayObjectUniqueItemsRequiredProperty.remove(arrayObjectUniqueItemsRequiredPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest arrayObjectUniqueItemsMinItemsProperty(Set<@Valid ValidationSubRequest> arrayObjectUniqueItemsMinItemsProperty) {
+        this.arrayObjectUniqueItemsMinItemsProperty = arrayObjectUniqueItemsMinItemsProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayObjectUniqueItemsMinItemsProperty")
+    @Valid @Size(min = 3) 
+    public Set<@Valid ValidationSubRequest> getArrayObjectUniqueItemsMinItemsProperty() {
+        return arrayObjectUniqueItemsMinItemsProperty;
+    }
+
+    @JsonProperty("arrayObjectUniqueItemsMinItemsProperty")
+    @JsonDeserialize(as = LinkedHashSet.class)
+    public void setArrayObjectUniqueItemsMinItemsProperty(Set<@Valid ValidationSubRequest> arrayObjectUniqueItemsMinItemsProperty) {
+        this.arrayObjectUniqueItemsMinItemsProperty = arrayObjectUniqueItemsMinItemsProperty;
+    }
+
+    public ValidationRequest addArrayObjectUniqueItemsMinItemsPropertyItem(ValidationSubRequest arrayObjectUniqueItemsMinItemsPropertyItem) {
+        if (this.arrayObjectUniqueItemsMinItemsProperty == null) {
+            this.arrayObjectUniqueItemsMinItemsProperty = new LinkedHashSet<>();
+        }
+
+        this.arrayObjectUniqueItemsMinItemsProperty.add(arrayObjectUniqueItemsMinItemsPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayObjectUniqueItemsMinItemsPropertyItem(ValidationSubRequest arrayObjectUniqueItemsMinItemsPropertyItem) {
+        if (arrayObjectUniqueItemsMinItemsPropertyItem != null && this.arrayObjectUniqueItemsMinItemsProperty != null) {
+            this.arrayObjectUniqueItemsMinItemsProperty.remove(arrayObjectUniqueItemsMinItemsPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest arrayObjectUniqueItemsMaxItemsProperty(Set<@Valid ValidationSubRequest> arrayObjectUniqueItemsMaxItemsProperty) {
+        this.arrayObjectUniqueItemsMaxItemsProperty = arrayObjectUniqueItemsMaxItemsProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayObjectUniqueItemsMaxItemsProperty")
+    @Valid @Size(max = 7) 
+    public Set<@Valid ValidationSubRequest> getArrayObjectUniqueItemsMaxItemsProperty() {
+        return arrayObjectUniqueItemsMaxItemsProperty;
+    }
+
+    @JsonProperty("arrayObjectUniqueItemsMaxItemsProperty")
+    @JsonDeserialize(as = LinkedHashSet.class)
+    public void setArrayObjectUniqueItemsMaxItemsProperty(Set<@Valid ValidationSubRequest> arrayObjectUniqueItemsMaxItemsProperty) {
+        this.arrayObjectUniqueItemsMaxItemsProperty = arrayObjectUniqueItemsMaxItemsProperty;
+    }
+
+    public ValidationRequest addArrayObjectUniqueItemsMaxItemsPropertyItem(ValidationSubRequest arrayObjectUniqueItemsMaxItemsPropertyItem) {
+        if (this.arrayObjectUniqueItemsMaxItemsProperty == null) {
+            this.arrayObjectUniqueItemsMaxItemsProperty = new LinkedHashSet<>();
+        }
+
+        this.arrayObjectUniqueItemsMaxItemsProperty.add(arrayObjectUniqueItemsMaxItemsPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayObjectUniqueItemsMaxItemsPropertyItem(ValidationSubRequest arrayObjectUniqueItemsMaxItemsPropertyItem) {
+        if (arrayObjectUniqueItemsMaxItemsPropertyItem != null && this.arrayObjectUniqueItemsMaxItemsProperty != null) {
+            this.arrayObjectUniqueItemsMaxItemsProperty.remove(arrayObjectUniqueItemsMaxItemsPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest arrayObjectUniqueItemsMinItemsMaxItemsProperty(Set<@Valid ValidationSubRequest> arrayObjectUniqueItemsMinItemsMaxItemsProperty) {
+        this.arrayObjectUniqueItemsMinItemsMaxItemsProperty = arrayObjectUniqueItemsMinItemsMaxItemsProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayObjectUniqueItemsMinItemsMaxItemsProperty")
+    @Valid @Size(min = 3, max = 7) 
+    public Set<@Valid ValidationSubRequest> getArrayObjectUniqueItemsMinItemsMaxItemsProperty() {
+        return arrayObjectUniqueItemsMinItemsMaxItemsProperty;
+    }
+
+    @JsonProperty("arrayObjectUniqueItemsMinItemsMaxItemsProperty")
+    @JsonDeserialize(as = LinkedHashSet.class)
+    public void setArrayObjectUniqueItemsMinItemsMaxItemsProperty(Set<@Valid ValidationSubRequest> arrayObjectUniqueItemsMinItemsMaxItemsProperty) {
+        this.arrayObjectUniqueItemsMinItemsMaxItemsProperty = arrayObjectUniqueItemsMinItemsMaxItemsProperty;
+    }
+
+    public ValidationRequest addArrayObjectUniqueItemsMinItemsMaxItemsPropertyItem(ValidationSubRequest arrayObjectUniqueItemsMinItemsMaxItemsPropertyItem) {
+        if (this.arrayObjectUniqueItemsMinItemsMaxItemsProperty == null) {
+            this.arrayObjectUniqueItemsMinItemsMaxItemsProperty = new LinkedHashSet<>();
+        }
+
+        this.arrayObjectUniqueItemsMinItemsMaxItemsProperty.add(arrayObjectUniqueItemsMinItemsMaxItemsPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayObjectUniqueItemsMinItemsMaxItemsPropertyItem(ValidationSubRequest arrayObjectUniqueItemsMinItemsMaxItemsPropertyItem) {
+        if (arrayObjectUniqueItemsMinItemsMaxItemsPropertyItem != null && this.arrayObjectUniqueItemsMinItemsMaxItemsProperty != null) {
+            this.arrayObjectUniqueItemsMinItemsMaxItemsProperty.remove(arrayObjectUniqueItemsMinItemsMaxItemsPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest arrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty(Set<@Valid ValidationSubRequest> arrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty) {
+        this.arrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty = arrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("arrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty")
+    @Required @Valid @Size(min = 3, max = 7) 
+    public Set<@Valid ValidationSubRequest> getArrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty() {
+        return arrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty;
+    }
+
+    @JsonProperty("arrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty")
+    @JsonDeserialize(as = LinkedHashSet.class)
+    public void setArrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty(Set<@Valid ValidationSubRequest> arrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty) {
+        this.arrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty = arrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty;
+    }
+
+    public ValidationRequest addArrayObjectUniqueItemsRequiredMinItemsMaxItemsPropertyItem(ValidationSubRequest arrayObjectUniqueItemsRequiredMinItemsMaxItemsPropertyItem) {
+        if (this.arrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty == null) {
+            this.arrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty = new LinkedHashSet<>();
+        }
+
+        this.arrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty.add(arrayObjectUniqueItemsRequiredMinItemsMaxItemsPropertyItem);
+        return this;
+    }
+
+    public ValidationRequest removeArrayObjectUniqueItemsRequiredMinItemsMaxItemsPropertyItem(ValidationSubRequest arrayObjectUniqueItemsRequiredMinItemsMaxItemsPropertyItem) {
+        if (arrayObjectUniqueItemsRequiredMinItemsMaxItemsPropertyItem != null && this.arrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty != null) {
+            this.arrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty.remove(arrayObjectUniqueItemsRequiredMinItemsMaxItemsPropertyItem);
+        }
+
+        return this;
+    }
+    /**
+     */
+    public ValidationRequest objectPlainProperty(ValidationSubRequest objectPlainProperty) {
+        this.objectPlainProperty = objectPlainProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("objectPlainProperty")
+    @Valid 
+    public ValidationSubRequest getObjectPlainProperty() {
+        return objectPlainProperty;
+    }
+
+    @JsonProperty("objectPlainProperty")
+    public void setObjectPlainProperty(ValidationSubRequest objectPlainProperty) {
+        this.objectPlainProperty = objectPlainProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest objectRequiredProperty(ValidationSubRequest objectRequiredProperty) {
+        this.objectRequiredProperty = objectRequiredProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("objectRequiredProperty")
+    @Required @Valid 
+    public ValidationSubRequest getObjectRequiredProperty() {
+        return objectRequiredProperty;
+    }
+
+    @JsonProperty("objectRequiredProperty")
+    public void setObjectRequiredProperty(ValidationSubRequest objectRequiredProperty) {
+        this.objectRequiredProperty = objectRequiredProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest enumPlainProperty(EnumPlainPropertyEnum enumPlainProperty) {
+        this.enumPlainProperty = enumPlainProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("enumPlainProperty")
+    
+    public EnumPlainPropertyEnum getEnumPlainProperty() {
+        return enumPlainProperty;
+    }
+
+    @JsonProperty("enumPlainProperty")
+    public void setEnumPlainProperty(EnumPlainPropertyEnum enumPlainProperty) {
+        this.enumPlainProperty = enumPlainProperty;
+    }
+
+    /**
+     */
+    public ValidationRequest enumRequiredProperty(EnumRequiredPropertyEnum enumRequiredProperty) {
+        this.enumRequiredProperty = enumRequiredProperty;
+        return this;
+    }
+
+    
+    @JsonProperty("enumRequiredProperty")
+    @Required 
+    public EnumRequiredPropertyEnum getEnumRequiredProperty() {
+        return enumRequiredProperty;
+    }
+
+    @JsonProperty("enumRequiredProperty")
+    public void setEnumRequiredProperty(EnumRequiredPropertyEnum enumRequiredProperty) {
+        this.enumRequiredProperty = enumRequiredProperty;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ValidationRequest validationRequest = (ValidationRequest) o;
+        return Objects.equals(this.integerPlainProperty, validationRequest.integerPlainProperty) &&
+            Objects.equals(this.integerRequiredProperty, validationRequest.integerRequiredProperty) &&
+            Objects.equals(this.integerMinimumProperty, validationRequest.integerMinimumProperty) &&
+            Objects.equals(this.integerMaximumProperty, validationRequest.integerMaximumProperty) &&
+            Objects.equals(this.integerMinimumMaximumProperty, validationRequest.integerMinimumMaximumProperty) &&
+            Objects.equals(this.integerRequiredMinimumMaximumProperty, validationRequest.integerRequiredMinimumMaximumProperty) &&
+            Objects.equals(this.integerInt32PlainProperty, validationRequest.integerInt32PlainProperty) &&
+            Objects.equals(this.integerInt32RequiredProperty, validationRequest.integerInt32RequiredProperty) &&
+            Objects.equals(this.integerInt32MinimumProperty, validationRequest.integerInt32MinimumProperty) &&
+            Objects.equals(this.integerInt32MaximumProperty, validationRequest.integerInt32MaximumProperty) &&
+            Objects.equals(this.integerInt32MinimumMaximumProperty, validationRequest.integerInt32MinimumMaximumProperty) &&
+            Objects.equals(this.integerInt32RequiredMinimumMaximumProperty, validationRequest.integerInt32RequiredMinimumMaximumProperty) &&
+            Objects.equals(this.integerInt64PlainProperty, validationRequest.integerInt64PlainProperty) &&
+            Objects.equals(this.integerInt64RequiredProperty, validationRequest.integerInt64RequiredProperty) &&
+            Objects.equals(this.integerInt64MinimumProperty, validationRequest.integerInt64MinimumProperty) &&
+            Objects.equals(this.integerInt64MaximumProperty, validationRequest.integerInt64MaximumProperty) &&
+            Objects.equals(this.integerInt64MinimumMaximumProperty, validationRequest.integerInt64MinimumMaximumProperty) &&
+            Objects.equals(this.integerInt64RequiredMinimumMaximumProperty, validationRequest.integerInt64RequiredMinimumMaximumProperty) &&
+            Objects.equals(this.numberPlainProperty, validationRequest.numberPlainProperty) &&
+            Objects.equals(this.numberRequiredProperty, validationRequest.numberRequiredProperty) &&
+            Objects.equals(this.numberMinimumProperty, validationRequest.numberMinimumProperty) &&
+            Objects.equals(this.numberMaximumProperty, validationRequest.numberMaximumProperty) &&
+            Objects.equals(this.numberMinimumMaximumProperty, validationRequest.numberMinimumMaximumProperty) &&
+            Objects.equals(this.numberRequiredMinimumMaximumProperty, validationRequest.numberRequiredMinimumMaximumProperty) &&
+            Objects.equals(this.numberFloatPlainProperty, validationRequest.numberFloatPlainProperty) &&
+            Objects.equals(this.numberFloatRequiredProperty, validationRequest.numberFloatRequiredProperty) &&
+            Objects.equals(this.numberFloatMinimumProperty, validationRequest.numberFloatMinimumProperty) &&
+            Objects.equals(this.numberFloatMaximumProperty, validationRequest.numberFloatMaximumProperty) &&
+            Objects.equals(this.numberFloatMinimumMaximumProperty, validationRequest.numberFloatMinimumMaximumProperty) &&
+            Objects.equals(this.numberFloatRequiredMinimumMaximumProperty, validationRequest.numberFloatRequiredMinimumMaximumProperty) &&
+            Objects.equals(this.numberDoublePlainProperty, validationRequest.numberDoublePlainProperty) &&
+            Objects.equals(this.numberDoubleRequiredProperty, validationRequest.numberDoubleRequiredProperty) &&
+            Objects.equals(this.numberDoubleMinimumProperty, validationRequest.numberDoubleMinimumProperty) &&
+            Objects.equals(this.numberDoubleMaximumProperty, validationRequest.numberDoubleMaximumProperty) &&
+            Objects.equals(this.numberDoubleMinimumMaximumProperty, validationRequest.numberDoubleMinimumMaximumProperty) &&
+            Objects.equals(this.numberDoubleRequiredMinimumMaximumProperty, validationRequest.numberDoubleRequiredMinimumMaximumProperty) &&
+            Objects.equals(this.booleanPlainProperty, validationRequest.booleanPlainProperty) &&
+            Objects.equals(this.booleanRequiredProperty, validationRequest.booleanRequiredProperty) &&
+            Objects.equals(this.stringPlainProperty, validationRequest.stringPlainProperty) &&
+            Objects.equals(this.stringRequiredProperty, validationRequest.stringRequiredProperty) &&
+            Objects.equals(this.stringMinLengthProperty, validationRequest.stringMinLengthProperty) &&
+            Objects.equals(this.stringMaxLengthProperty, validationRequest.stringMaxLengthProperty) &&
+            Objects.equals(this.stringMinLengthMaxLengthProperty, validationRequest.stringMinLengthMaxLengthProperty) &&
+            Objects.equals(this.stringPatternProperty, validationRequest.stringPatternProperty) &&
+            Objects.equals(this.stringRequiredMinLengthMaxLengthPatternProperty, validationRequest.stringRequiredMinLengthMaxLengthPatternProperty) &&
+            Arrays.equals(this.stringByteArrayProperty, validationRequest.stringByteArrayProperty) &&
+            Arrays.equals(this.stringByteArrayMinLengthProperty, validationRequest.stringByteArrayMinLengthProperty) &&
+            Arrays.equals(this.stringByteArrayMaxLengthProperty, validationRequest.stringByteArrayMaxLengthProperty) &&
+            Arrays.equals(this.stringByteArrayMinLengthMaxLengthProperty, validationRequest.stringByteArrayMinLengthMaxLengthProperty) &&
+            Arrays.equals(this.stringByteArrayRequiredMinLengthMaxLengthProperty, validationRequest.stringByteArrayRequiredMinLengthMaxLengthProperty) &&
+            Objects.equals(this.stringDatePlainProperty, validationRequest.stringDatePlainProperty) &&
+            Objects.equals(this.stringDateRequiredProperty, validationRequest.stringDateRequiredProperty) &&
+            Objects.equals(this.stringDateTimePlainProperty, validationRequest.stringDateTimePlainProperty) &&
+            Objects.equals(this.stringDateTimeRequiredProperty, validationRequest.stringDateTimeRequiredProperty) &&
+            Objects.equals(this.stringPasswordPlainProperty, validationRequest.stringPasswordPlainProperty) &&
+            Objects.equals(this.stringPasswordRequiredProperty, validationRequest.stringPasswordRequiredProperty) &&
+            Objects.equals(this.stringPasswordMinLengthProperty, validationRequest.stringPasswordMinLengthProperty) &&
+            Objects.equals(this.stringPasswordMaxLengthProperty, validationRequest.stringPasswordMaxLengthProperty) &&
+            Objects.equals(this.stringPasswordMinLengthMaxLengthProperty, validationRequest.stringPasswordMinLengthMaxLengthProperty) &&
+            Objects.equals(this.stringPasswordPatternProperty, validationRequest.stringPasswordPatternProperty) &&
+            Objects.equals(this.stringPasswordRequiredMinLengthMaxLengthPatternProperty, validationRequest.stringPasswordRequiredMinLengthMaxLengthPatternProperty) &&
+            Objects.equals(this.stringNumberPlainProperty, validationRequest.stringNumberPlainProperty) &&
+            Objects.equals(this.stringNumberRequiredProperty, validationRequest.stringNumberRequiredProperty) &&
+            Objects.equals(this.stringUriPlainProperty, validationRequest.stringUriPlainProperty) &&
+            Objects.equals(this.stringUriRequiredProperty, validationRequest.stringUriRequiredProperty) &&
+            Objects.equals(this.stringUuidPlainProperty, validationRequest.stringUuidPlainProperty) &&
+            Objects.equals(this.stringUuidRequiredProperty, validationRequest.stringUuidRequiredProperty) &&
+            Objects.equals(this.stringRegexPlainProperty, validationRequest.stringRegexPlainProperty) &&
+            Objects.equals(this.stringRegexRequiredProperty, validationRequest.stringRegexRequiredProperty) &&
+            Objects.equals(this.stringRegexMinLengthProperty, validationRequest.stringRegexMinLengthProperty) &&
+            Objects.equals(this.stringRegexMaxLengthProperty, validationRequest.stringRegexMaxLengthProperty) &&
+            Objects.equals(this.stringRegexMinLengthMaxLengthProperty, validationRequest.stringRegexMinLengthMaxLengthProperty) &&
+            Objects.equals(this.stringRegexRequiredMinLengthMaxLengthProperty, validationRequest.stringRegexRequiredMinLengthMaxLengthProperty) &&
+            Objects.equals(this.arrayStringPlainProperty, validationRequest.arrayStringPlainProperty) &&
+            Objects.equals(this.arrayStringRequiredProperty, validationRequest.arrayStringRequiredProperty) &&
+            Objects.equals(this.arrayStringMinItemsProperty, validationRequest.arrayStringMinItemsProperty) &&
+            Objects.equals(this.arrayStringMaxItemsProperty, validationRequest.arrayStringMaxItemsProperty) &&
+            Objects.equals(this.arrayStringMinItemsMaxItemsProperty, validationRequest.arrayStringMinItemsMaxItemsProperty) &&
+            Objects.equals(this.arrayStringRequiredMinItemsMaxItemsProperty, validationRequest.arrayStringRequiredMinItemsMaxItemsProperty) &&
+            Objects.equals(this.arrayObjectPlainProperty, validationRequest.arrayObjectPlainProperty) &&
+            Objects.equals(this.arrayObjectRequiredProperty, validationRequest.arrayObjectRequiredProperty) &&
+            Objects.equals(this.arrayObjectMinItemsProperty, validationRequest.arrayObjectMinItemsProperty) &&
+            Objects.equals(this.arrayObjectMaxItemsProperty, validationRequest.arrayObjectMaxItemsProperty) &&
+            Objects.equals(this.arrayObjectMinItemsMaxItemsProperty, validationRequest.arrayObjectMinItemsMaxItemsProperty) &&
+            Objects.equals(this.arrayObjectRequiredMinItemsMaxItemsProperty, validationRequest.arrayObjectRequiredMinItemsMaxItemsProperty) &&
+            Objects.equals(this.arrayStringUniqueItemsPlainProperty, validationRequest.arrayStringUniqueItemsPlainProperty) &&
+            Objects.equals(this.arrayStringUniqueItemsRequiredProperty, validationRequest.arrayStringUniqueItemsRequiredProperty) &&
+            Objects.equals(this.arrayStringUniqueItemsMinItemsProperty, validationRequest.arrayStringUniqueItemsMinItemsProperty) &&
+            Objects.equals(this.arrayStringUniqueItemsMaxItemsProperty, validationRequest.arrayStringUniqueItemsMaxItemsProperty) &&
+            Objects.equals(this.arrayStringUniqueItemsMinItemsMaxItemsProperty, validationRequest.arrayStringUniqueItemsMinItemsMaxItemsProperty) &&
+            Objects.equals(this.arrayStringUniqueItemsRequiredMinItemsMaxItemsProperty, validationRequest.arrayStringUniqueItemsRequiredMinItemsMaxItemsProperty) &&
+            Objects.equals(this.arrayObjectUniqueItemsPlainProperty, validationRequest.arrayObjectUniqueItemsPlainProperty) &&
+            Objects.equals(this.arrayObjectUniqueItemsRequiredProperty, validationRequest.arrayObjectUniqueItemsRequiredProperty) &&
+            Objects.equals(this.arrayObjectUniqueItemsMinItemsProperty, validationRequest.arrayObjectUniqueItemsMinItemsProperty) &&
+            Objects.equals(this.arrayObjectUniqueItemsMaxItemsProperty, validationRequest.arrayObjectUniqueItemsMaxItemsProperty) &&
+            Objects.equals(this.arrayObjectUniqueItemsMinItemsMaxItemsProperty, validationRequest.arrayObjectUniqueItemsMinItemsMaxItemsProperty) &&
+            Objects.equals(this.arrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty, validationRequest.arrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty) &&
+            Objects.equals(this.objectPlainProperty, validationRequest.objectPlainProperty) &&
+            Objects.equals(this.objectRequiredProperty, validationRequest.objectRequiredProperty) &&
+            Objects.equals(this.enumPlainProperty, validationRequest.enumPlainProperty) &&
+            Objects.equals(this.enumRequiredProperty, validationRequest.enumRequiredProperty);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(integerPlainProperty, integerRequiredProperty, integerMinimumProperty, integerMaximumProperty, integerMinimumMaximumProperty, integerRequiredMinimumMaximumProperty, integerInt32PlainProperty, integerInt32RequiredProperty, integerInt32MinimumProperty, integerInt32MaximumProperty, integerInt32MinimumMaximumProperty, integerInt32RequiredMinimumMaximumProperty, integerInt64PlainProperty, integerInt64RequiredProperty, integerInt64MinimumProperty, integerInt64MaximumProperty, integerInt64MinimumMaximumProperty, integerInt64RequiredMinimumMaximumProperty, numberPlainProperty, numberRequiredProperty, numberMinimumProperty, numberMaximumProperty, numberMinimumMaximumProperty, numberRequiredMinimumMaximumProperty, numberFloatPlainProperty, numberFloatRequiredProperty, numberFloatMinimumProperty, numberFloatMaximumProperty, numberFloatMinimumMaximumProperty, numberFloatRequiredMinimumMaximumProperty, numberDoublePlainProperty, numberDoubleRequiredProperty, numberDoubleMinimumProperty, numberDoubleMaximumProperty, numberDoubleMinimumMaximumProperty, numberDoubleRequiredMinimumMaximumProperty, booleanPlainProperty, booleanRequiredProperty, stringPlainProperty, stringRequiredProperty, stringMinLengthProperty, stringMaxLengthProperty, stringMinLengthMaxLengthProperty, stringPatternProperty, stringRequiredMinLengthMaxLengthPatternProperty, Arrays.hashCode(stringByteArrayProperty), Arrays.hashCode(stringByteArrayMinLengthProperty), Arrays.hashCode(stringByteArrayMaxLengthProperty), Arrays.hashCode(stringByteArrayMinLengthMaxLengthProperty), Arrays.hashCode(stringByteArrayRequiredMinLengthMaxLengthProperty), stringDatePlainProperty, stringDateRequiredProperty, stringDateTimePlainProperty, stringDateTimeRequiredProperty, stringPasswordPlainProperty, stringPasswordRequiredProperty, stringPasswordMinLengthProperty, stringPasswordMaxLengthProperty, stringPasswordMinLengthMaxLengthProperty, stringPasswordPatternProperty, stringPasswordRequiredMinLengthMaxLengthPatternProperty, stringNumberPlainProperty, stringNumberRequiredProperty, stringUriPlainProperty, stringUriRequiredProperty, stringUuidPlainProperty, stringUuidRequiredProperty, stringRegexPlainProperty, stringRegexRequiredProperty, stringRegexMinLengthProperty, stringRegexMaxLengthProperty, stringRegexMinLengthMaxLengthProperty, stringRegexRequiredMinLengthMaxLengthProperty, arrayStringPlainProperty, arrayStringRequiredProperty, arrayStringMinItemsProperty, arrayStringMaxItemsProperty, arrayStringMinItemsMaxItemsProperty, arrayStringRequiredMinItemsMaxItemsProperty, arrayObjectPlainProperty, arrayObjectRequiredProperty, arrayObjectMinItemsProperty, arrayObjectMaxItemsProperty, arrayObjectMinItemsMaxItemsProperty, arrayObjectRequiredMinItemsMaxItemsProperty, arrayStringUniqueItemsPlainProperty, arrayStringUniqueItemsRequiredProperty, arrayStringUniqueItemsMinItemsProperty, arrayStringUniqueItemsMaxItemsProperty, arrayStringUniqueItemsMinItemsMaxItemsProperty, arrayStringUniqueItemsRequiredMinItemsMaxItemsProperty, arrayObjectUniqueItemsPlainProperty, arrayObjectUniqueItemsRequiredProperty, arrayObjectUniqueItemsMinItemsProperty, arrayObjectUniqueItemsMaxItemsProperty, arrayObjectUniqueItemsMinItemsMaxItemsProperty, arrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty, objectPlainProperty, objectRequiredProperty, enumPlainProperty, enumRequiredProperty);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ValidationRequest {\n");
+        
+        sb.append("    integerPlainProperty: ").append(toIndentedString(integerPlainProperty)).append("\n");
+        sb.append("    integerRequiredProperty: ").append(toIndentedString(integerRequiredProperty)).append("\n");
+        sb.append("    integerMinimumProperty: ").append(toIndentedString(integerMinimumProperty)).append("\n");
+        sb.append("    integerMaximumProperty: ").append(toIndentedString(integerMaximumProperty)).append("\n");
+        sb.append("    integerMinimumMaximumProperty: ").append(toIndentedString(integerMinimumMaximumProperty)).append("\n");
+        sb.append("    integerRequiredMinimumMaximumProperty: ").append(toIndentedString(integerRequiredMinimumMaximumProperty)).append("\n");
+        sb.append("    integerInt32PlainProperty: ").append(toIndentedString(integerInt32PlainProperty)).append("\n");
+        sb.append("    integerInt32RequiredProperty: ").append(toIndentedString(integerInt32RequiredProperty)).append("\n");
+        sb.append("    integerInt32MinimumProperty: ").append(toIndentedString(integerInt32MinimumProperty)).append("\n");
+        sb.append("    integerInt32MaximumProperty: ").append(toIndentedString(integerInt32MaximumProperty)).append("\n");
+        sb.append("    integerInt32MinimumMaximumProperty: ").append(toIndentedString(integerInt32MinimumMaximumProperty)).append("\n");
+        sb.append("    integerInt32RequiredMinimumMaximumProperty: ").append(toIndentedString(integerInt32RequiredMinimumMaximumProperty)).append("\n");
+        sb.append("    integerInt64PlainProperty: ").append(toIndentedString(integerInt64PlainProperty)).append("\n");
+        sb.append("    integerInt64RequiredProperty: ").append(toIndentedString(integerInt64RequiredProperty)).append("\n");
+        sb.append("    integerInt64MinimumProperty: ").append(toIndentedString(integerInt64MinimumProperty)).append("\n");
+        sb.append("    integerInt64MaximumProperty: ").append(toIndentedString(integerInt64MaximumProperty)).append("\n");
+        sb.append("    integerInt64MinimumMaximumProperty: ").append(toIndentedString(integerInt64MinimumMaximumProperty)).append("\n");
+        sb.append("    integerInt64RequiredMinimumMaximumProperty: ").append(toIndentedString(integerInt64RequiredMinimumMaximumProperty)).append("\n");
+        sb.append("    numberPlainProperty: ").append(toIndentedString(numberPlainProperty)).append("\n");
+        sb.append("    numberRequiredProperty: ").append(toIndentedString(numberRequiredProperty)).append("\n");
+        sb.append("    numberMinimumProperty: ").append(toIndentedString(numberMinimumProperty)).append("\n");
+        sb.append("    numberMaximumProperty: ").append(toIndentedString(numberMaximumProperty)).append("\n");
+        sb.append("    numberMinimumMaximumProperty: ").append(toIndentedString(numberMinimumMaximumProperty)).append("\n");
+        sb.append("    numberRequiredMinimumMaximumProperty: ").append(toIndentedString(numberRequiredMinimumMaximumProperty)).append("\n");
+        sb.append("    numberFloatPlainProperty: ").append(toIndentedString(numberFloatPlainProperty)).append("\n");
+        sb.append("    numberFloatRequiredProperty: ").append(toIndentedString(numberFloatRequiredProperty)).append("\n");
+        sb.append("    numberFloatMinimumProperty: ").append(toIndentedString(numberFloatMinimumProperty)).append("\n");
+        sb.append("    numberFloatMaximumProperty: ").append(toIndentedString(numberFloatMaximumProperty)).append("\n");
+        sb.append("    numberFloatMinimumMaximumProperty: ").append(toIndentedString(numberFloatMinimumMaximumProperty)).append("\n");
+        sb.append("    numberFloatRequiredMinimumMaximumProperty: ").append(toIndentedString(numberFloatRequiredMinimumMaximumProperty)).append("\n");
+        sb.append("    numberDoublePlainProperty: ").append(toIndentedString(numberDoublePlainProperty)).append("\n");
+        sb.append("    numberDoubleRequiredProperty: ").append(toIndentedString(numberDoubleRequiredProperty)).append("\n");
+        sb.append("    numberDoubleMinimumProperty: ").append(toIndentedString(numberDoubleMinimumProperty)).append("\n");
+        sb.append("    numberDoubleMaximumProperty: ").append(toIndentedString(numberDoubleMaximumProperty)).append("\n");
+        sb.append("    numberDoubleMinimumMaximumProperty: ").append(toIndentedString(numberDoubleMinimumMaximumProperty)).append("\n");
+        sb.append("    numberDoubleRequiredMinimumMaximumProperty: ").append(toIndentedString(numberDoubleRequiredMinimumMaximumProperty)).append("\n");
+        sb.append("    booleanPlainProperty: ").append(toIndentedString(booleanPlainProperty)).append("\n");
+        sb.append("    booleanRequiredProperty: ").append(toIndentedString(booleanRequiredProperty)).append("\n");
+        sb.append("    stringPlainProperty: ").append(toIndentedString(stringPlainProperty)).append("\n");
+        sb.append("    stringRequiredProperty: ").append(toIndentedString(stringRequiredProperty)).append("\n");
+        sb.append("    stringMinLengthProperty: ").append(toIndentedString(stringMinLengthProperty)).append("\n");
+        sb.append("    stringMaxLengthProperty: ").append(toIndentedString(stringMaxLengthProperty)).append("\n");
+        sb.append("    stringMinLengthMaxLengthProperty: ").append(toIndentedString(stringMinLengthMaxLengthProperty)).append("\n");
+        sb.append("    stringPatternProperty: ").append(toIndentedString(stringPatternProperty)).append("\n");
+        sb.append("    stringRequiredMinLengthMaxLengthPatternProperty: ").append(toIndentedString(stringRequiredMinLengthMaxLengthPatternProperty)).append("\n");
+        sb.append("    stringByteArrayProperty: ").append(toIndentedString(stringByteArrayProperty)).append("\n");
+        sb.append("    stringByteArrayMinLengthProperty: ").append(toIndentedString(stringByteArrayMinLengthProperty)).append("\n");
+        sb.append("    stringByteArrayMaxLengthProperty: ").append(toIndentedString(stringByteArrayMaxLengthProperty)).append("\n");
+        sb.append("    stringByteArrayMinLengthMaxLengthProperty: ").append(toIndentedString(stringByteArrayMinLengthMaxLengthProperty)).append("\n");
+        sb.append("    stringByteArrayRequiredMinLengthMaxLengthProperty: ").append(toIndentedString(stringByteArrayRequiredMinLengthMaxLengthProperty)).append("\n");
+        sb.append("    stringDatePlainProperty: ").append(toIndentedString(stringDatePlainProperty)).append("\n");
+        sb.append("    stringDateRequiredProperty: ").append(toIndentedString(stringDateRequiredProperty)).append("\n");
+        sb.append("    stringDateTimePlainProperty: ").append(toIndentedString(stringDateTimePlainProperty)).append("\n");
+        sb.append("    stringDateTimeRequiredProperty: ").append(toIndentedString(stringDateTimeRequiredProperty)).append("\n");
+        sb.append("    stringPasswordPlainProperty: ").append(toIndentedString(stringPasswordPlainProperty)).append("\n");
+        sb.append("    stringPasswordRequiredProperty: ").append(toIndentedString(stringPasswordRequiredProperty)).append("\n");
+        sb.append("    stringPasswordMinLengthProperty: ").append(toIndentedString(stringPasswordMinLengthProperty)).append("\n");
+        sb.append("    stringPasswordMaxLengthProperty: ").append(toIndentedString(stringPasswordMaxLengthProperty)).append("\n");
+        sb.append("    stringPasswordMinLengthMaxLengthProperty: ").append(toIndentedString(stringPasswordMinLengthMaxLengthProperty)).append("\n");
+        sb.append("    stringPasswordPatternProperty: ").append(toIndentedString(stringPasswordPatternProperty)).append("\n");
+        sb.append("    stringPasswordRequiredMinLengthMaxLengthPatternProperty: ").append(toIndentedString(stringPasswordRequiredMinLengthMaxLengthPatternProperty)).append("\n");
+        sb.append("    stringNumberPlainProperty: ").append(toIndentedString(stringNumberPlainProperty)).append("\n");
+        sb.append("    stringNumberRequiredProperty: ").append(toIndentedString(stringNumberRequiredProperty)).append("\n");
+        sb.append("    stringUriPlainProperty: ").append(toIndentedString(stringUriPlainProperty)).append("\n");
+        sb.append("    stringUriRequiredProperty: ").append(toIndentedString(stringUriRequiredProperty)).append("\n");
+        sb.append("    stringUuidPlainProperty: ").append(toIndentedString(stringUuidPlainProperty)).append("\n");
+        sb.append("    stringUuidRequiredProperty: ").append(toIndentedString(stringUuidRequiredProperty)).append("\n");
+        sb.append("    stringRegexPlainProperty: ").append(toIndentedString(stringRegexPlainProperty)).append("\n");
+        sb.append("    stringRegexRequiredProperty: ").append(toIndentedString(stringRegexRequiredProperty)).append("\n");
+        sb.append("    stringRegexMinLengthProperty: ").append(toIndentedString(stringRegexMinLengthProperty)).append("\n");
+        sb.append("    stringRegexMaxLengthProperty: ").append(toIndentedString(stringRegexMaxLengthProperty)).append("\n");
+        sb.append("    stringRegexMinLengthMaxLengthProperty: ").append(toIndentedString(stringRegexMinLengthMaxLengthProperty)).append("\n");
+        sb.append("    stringRegexRequiredMinLengthMaxLengthProperty: ").append(toIndentedString(stringRegexRequiredMinLengthMaxLengthProperty)).append("\n");
+        sb.append("    arrayStringPlainProperty: ").append(toIndentedString(arrayStringPlainProperty)).append("\n");
+        sb.append("    arrayStringRequiredProperty: ").append(toIndentedString(arrayStringRequiredProperty)).append("\n");
+        sb.append("    arrayStringMinItemsProperty: ").append(toIndentedString(arrayStringMinItemsProperty)).append("\n");
+        sb.append("    arrayStringMaxItemsProperty: ").append(toIndentedString(arrayStringMaxItemsProperty)).append("\n");
+        sb.append("    arrayStringMinItemsMaxItemsProperty: ").append(toIndentedString(arrayStringMinItemsMaxItemsProperty)).append("\n");
+        sb.append("    arrayStringRequiredMinItemsMaxItemsProperty: ").append(toIndentedString(arrayStringRequiredMinItemsMaxItemsProperty)).append("\n");
+        sb.append("    arrayObjectPlainProperty: ").append(toIndentedString(arrayObjectPlainProperty)).append("\n");
+        sb.append("    arrayObjectRequiredProperty: ").append(toIndentedString(arrayObjectRequiredProperty)).append("\n");
+        sb.append("    arrayObjectMinItemsProperty: ").append(toIndentedString(arrayObjectMinItemsProperty)).append("\n");
+        sb.append("    arrayObjectMaxItemsProperty: ").append(toIndentedString(arrayObjectMaxItemsProperty)).append("\n");
+        sb.append("    arrayObjectMinItemsMaxItemsProperty: ").append(toIndentedString(arrayObjectMinItemsMaxItemsProperty)).append("\n");
+        sb.append("    arrayObjectRequiredMinItemsMaxItemsProperty: ").append(toIndentedString(arrayObjectRequiredMinItemsMaxItemsProperty)).append("\n");
+        sb.append("    arrayStringUniqueItemsPlainProperty: ").append(toIndentedString(arrayStringUniqueItemsPlainProperty)).append("\n");
+        sb.append("    arrayStringUniqueItemsRequiredProperty: ").append(toIndentedString(arrayStringUniqueItemsRequiredProperty)).append("\n");
+        sb.append("    arrayStringUniqueItemsMinItemsProperty: ").append(toIndentedString(arrayStringUniqueItemsMinItemsProperty)).append("\n");
+        sb.append("    arrayStringUniqueItemsMaxItemsProperty: ").append(toIndentedString(arrayStringUniqueItemsMaxItemsProperty)).append("\n");
+        sb.append("    arrayStringUniqueItemsMinItemsMaxItemsProperty: ").append(toIndentedString(arrayStringUniqueItemsMinItemsMaxItemsProperty)).append("\n");
+        sb.append("    arrayStringUniqueItemsRequiredMinItemsMaxItemsProperty: ").append(toIndentedString(arrayStringUniqueItemsRequiredMinItemsMaxItemsProperty)).append("\n");
+        sb.append("    arrayObjectUniqueItemsPlainProperty: ").append(toIndentedString(arrayObjectUniqueItemsPlainProperty)).append("\n");
+        sb.append("    arrayObjectUniqueItemsRequiredProperty: ").append(toIndentedString(arrayObjectUniqueItemsRequiredProperty)).append("\n");
+        sb.append("    arrayObjectUniqueItemsMinItemsProperty: ").append(toIndentedString(arrayObjectUniqueItemsMinItemsProperty)).append("\n");
+        sb.append("    arrayObjectUniqueItemsMaxItemsProperty: ").append(toIndentedString(arrayObjectUniqueItemsMaxItemsProperty)).append("\n");
+        sb.append("    arrayObjectUniqueItemsMinItemsMaxItemsProperty: ").append(toIndentedString(arrayObjectUniqueItemsMinItemsMaxItemsProperty)).append("\n");
+        sb.append("    arrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty: ").append(toIndentedString(arrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty)).append("\n");
+        sb.append("    objectPlainProperty: ").append(toIndentedString(objectPlainProperty)).append("\n");
+        sb.append("    objectRequiredProperty: ").append(toIndentedString(objectRequiredProperty)).append("\n");
+        sb.append("    enumPlainProperty: ").append(toIndentedString(enumPlainProperty)).append("\n");
+        sb.append("    enumRequiredProperty: ").append(toIndentedString(enumRequiredProperty)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/ValidationVariationTest/allSupportedValidations/expected/src/gen/java/org/openapitools/model/ValidationResponse.java
+++ b/src/test/resources/openapi-3_0/ValidationVariationTest/allSupportedValidations/expected/src/gen/java/org/openapitools/model/ValidationResponse.java
@@ -1,0 +1,84 @@
+package org.openapitools.model;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import java.util.Arrays;
+import nablarch.core.validation.ee.DecimalRange;
+import nablarch.core.validation.ee.Length;
+import nablarch.core.validation.ee.NumberRange;
+import nablarch.core.validation.ee.Required;
+import nablarch.core.validation.ee.Size;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+
+@JsonTypeName("ValidationResponse")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:40:02.319711249+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ValidationResponse   {
+  private String message;
+
+    /**
+     */
+    public ValidationResponse message(String message) {
+        this.message = message;
+        return this;
+    }
+
+    
+    @JsonProperty("message")
+    
+    public String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ValidationResponse validationResponse = (ValidationResponse) o;
+        return Objects.equals(this.message, validationResponse.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(message);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ValidationResponse {\n");
+        
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/ValidationVariationTest/allSupportedValidations/expected/src/gen/java/org/openapitools/model/ValidationSubRequest.java
+++ b/src/test/resources/openapi-3_0/ValidationVariationTest/allSupportedValidations/expected/src/gen/java/org/openapitools/model/ValidationSubRequest.java
@@ -1,0 +1,84 @@
+package org.openapitools.model;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import java.util.Arrays;
+import nablarch.core.validation.ee.DecimalRange;
+import nablarch.core.validation.ee.Length;
+import nablarch.core.validation.ee.NumberRange;
+import nablarch.core.validation.ee.Required;
+import nablarch.core.validation.ee.Size;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+
+@JsonTypeName("ValidationSubRequest")
+@jakarta.annotation.Generated(value = "nablarch.tool.openapi.codegen.JavaNablarchJaxrsServerCodegen", date = "2024-12-09T21:40:02.319711249+09:00[Asia/Tokyo]", comments = "Generator version: 7.10.0")
+public class ValidationSubRequest   {
+  private String name;
+
+    /**
+     */
+    public ValidationSubRequest name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    
+    @JsonProperty("name")
+    @Required 
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ValidationSubRequest validationSubRequest = (ValidationSubRequest) o;
+        return Objects.equals(this.name, validationSubRequest.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ValidationSubRequest {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}
+

--- a/src/test/resources/openapi-3_0/ValidationVariationTest/validations.yaml
+++ b/src/test/resources/openapi-3_0/ValidationVariationTest/validations.yaml
@@ -1,0 +1,497 @@
+---
+openapi: 3.0.3
+info:
+  title: OpenAPI Sample
+  version: 0.0.1
+servers:
+- url: http://localhost:8080
+  description: OpenAPI Sample description
+paths:
+  /validations:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ValidationResponse'
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationResponse'
+components:
+  schemas:
+    ValidationRequest:
+      required:
+      - integerRequiredProperty
+      - integerRequiredMinimumMaximumProperty
+      - integerInt32RequiredProperty
+      - integerInt32RequiredMinimumMaximumProperty
+      - integerInt64RequiredProperty
+      - integerInt64RequiredMinimumMaximumProperty
+      - numberRequiredProperty
+      - numberRequiredMinimumMaximumProperty
+      - numberFloatRequiredProperty
+      - numberFloatRequiredMinimumMaximumProperty
+      - numberDoubleRequiredProperty
+      - numberDoubleRequiredMinimumMaximumProperty
+      - booleanRequiredProperty
+      - stringRequiredProperty
+      - stringRequiredMinLengthMaxLengthPatternProperty
+      - stringByteArrayProperty
+      - stringByteArrayRequiredMinLengthMaxLengthProperty
+      - stringDateRequiredProperty
+      - stringDateTimeRequiredProperty
+      - stringPasswordRequiredProperty
+      - stringPasswordRequiredMinLengthMaxLengthPatternProperty
+      - stringNumberRequiredProperty
+      - stringUriRequiredProperty
+      - stringUuidRequiredProperty
+      - stringRegexRequiredMinLengthMaxLengthProperty
+      - stringRegexRequiredProperty
+      - arrayStringRequiredProperty
+      - arrayStringRequiredMinItemsMaxItemsProperty
+      - arrayObjectRequiredProperty
+      - arrayObjectRequiredMinItemsMaxItemsProperty
+      - arrayStringUniqueItemsRequiredProperty
+      - arrayStringUniqueItemsRequiredMinItemsMaxItemsProperty
+      - arrayObjectUniqueItemsRequiredProperty
+      - arrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty
+      - objectRequiredProperty
+      - enumRequiredProperty
+      type: object
+      properties:
+        integerPlainProperty:
+          type: integer
+        integerRequiredProperty:
+          type: integer
+        integerMinimumProperty:
+          minimum: 3
+          type: integer
+        integerMaximumProperty:
+          maximum: 7
+          type: integer
+        integerMinimumMaximumProperty:
+          maximum: 7
+          minimum: 3
+          type: integer
+        integerRequiredMinimumMaximumProperty:
+          maximum: 7
+          minimum: 3
+          type: integer
+        integerInt32PlainProperty:
+          format: int32
+          type: integer
+        integerInt32RequiredProperty:
+          format: int32
+          type: integer
+        integerInt32MinimumProperty:
+          format: int32
+          minimum: 3
+          type: integer
+        integerInt32MaximumProperty:
+          format: int32
+          maximum: 7
+          type: integer
+        integerInt32MinimumMaximumProperty:
+          format: int32
+          maximum: 7
+          minimum: 3
+          type: integer
+        integerInt32RequiredMinimumMaximumProperty:
+          format: int32
+          maximum: 7
+          minimum: 3
+          type: integer
+        integerInt64PlainProperty:
+          format: int64
+          type: integer
+        integerInt64RequiredProperty:
+          format: int64
+          type: integer
+        integerInt64MinimumProperty:
+          format: int64
+          minimum: 3
+          type: integer
+        integerInt64MaximumProperty:
+          format: int64
+          maximum: 7
+          type: integer
+        integerInt64MinimumMaximumProperty:
+          format: int64
+          maximum: 7
+          minimum: 3
+          type: integer
+        integerInt64RequiredMinimumMaximumProperty:
+          format: int64
+          maximum: 7
+          minimum: 3
+          type: integer
+        numberPlainProperty:
+          type: number
+        numberRequiredProperty:
+          type: number
+        numberMinimumProperty:
+          minimum: 3.2
+          type: number
+        numberMaximumProperty:
+          maximum: 7.5
+          type: number
+        numberMinimumMaximumProperty:
+          maximum: 7.5
+          minimum: 3.2
+          type: number
+        numberRequiredMinimumMaximumProperty:
+          maximum: 7.5
+          minimum: 3.2
+          type: number
+        numberFloatPlainProperty:
+          format: float
+          type: number
+        numberFloatRequiredProperty:
+          format: float
+          type: number
+        numberFloatMinimumProperty:
+          format: float
+          minimum: 3.2
+          type: number
+        numberFloatMaximumProperty:
+          format: float
+          maximum: 7.5
+          type: number
+        numberFloatMinimumMaximumProperty:
+          format: float
+          maximum: 7.5
+          minimum: 3.2
+          type: number
+        numberFloatRequiredMinimumMaximumProperty:
+          format: float
+          maximum: 7.5
+          minimum: 3.2
+          type: number
+        numberDoublePlainProperty:
+          format: double
+          type: number
+        numberDoubleRequiredProperty:
+          format: double
+          type: number
+        numberDoubleMinimumProperty:
+          format: double
+          minimum: 3.2
+          type: number
+        numberDoubleMaximumProperty:
+          format: double
+          maximum: 7.5
+          type: number
+        numberDoubleMinimumMaximumProperty:
+          format: double
+          maximum: 7.5
+          minimum: 3.2
+          type: number
+        numberDoubleRequiredMinimumMaximumProperty:
+          format: double
+          maximum: 7.5
+          minimum: 3.2
+          type: number
+        booleanPlainProperty:
+          type: boolean
+        booleanRequiredProperty:
+          type: boolean
+        stringPlainProperty:
+          type: string
+        stringRequiredProperty:
+          type: string
+        stringMinLengthProperty:
+          minLength: 3
+          type: string
+        stringMaxLengthProperty:
+          maxLength: 7
+          type: string
+        stringMinLengthMaxLengthProperty:
+          maxLength: 7
+          minLength: 3
+          type: string
+        stringPatternProperty:
+          pattern: "[a-z]+"
+          type: string
+        stringRequiredMinLengthMaxLengthPatternProperty:
+          maxLength: 7
+          minLength: 3
+          pattern: "[a-z]+"
+          type: string
+        stringByteArrayProperty:
+          format: byte
+          type: string
+        stringByteArrayMinLengthProperty:
+          format: byte
+          minLength: 3
+          type: string
+        stringByteArrayMaxLengthProperty:
+          format: byte
+          maxLength: 7
+          type: string
+        stringByteArrayMinLengthMaxLengthProperty:
+          format: byte
+          maxLength: 7
+          minLength: 3
+          type: string
+        stringByteArrayRequiredMinLengthMaxLengthProperty:
+          format: byte
+          maxLength: 7
+          minLength: 3
+          type: string
+        stringDatePlainProperty:
+          format: date
+          type: string
+          example: 2022-03-10
+        stringDateRequiredProperty:
+          format: date
+          type: string
+          example: 2022-03-10
+        stringDateTimePlainProperty:
+          format: date-time
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        stringDateTimeRequiredProperty:
+          format: date-time
+          type: string
+          example: 2022-03-10T12:15:50-04:00
+        stringPasswordPlainProperty:
+          type: string
+        stringPasswordRequiredProperty:
+          type: string
+        stringPasswordMinLengthProperty:
+          minLength: 3
+          type: string
+        stringPasswordMaxLengthProperty:
+          maxLength: 7
+          type: string
+        stringPasswordMinLengthMaxLengthProperty:
+          maxLength: 7
+          minLength: 3
+          type: string
+        stringPasswordPatternProperty:
+          pattern: "[a-z]+"
+          type: string
+        stringPasswordRequiredMinLengthMaxLengthPatternProperty:
+          maxLength: 7
+          minLength: 3
+          pattern: "[a-z]+"
+          type: string
+        stringNumberPlainProperty:
+          format: number
+          type: string
+        stringNumberRequiredProperty:
+          format: number
+          type: string
+        stringUriPlainProperty:
+          format: uri
+          type: string
+        stringUriRequiredProperty:
+          format: uri
+          type: string
+        stringUuidPlainProperty:
+          format: uuid
+          type: string
+        stringUuidRequiredProperty:
+          format: uuid
+          type: string
+        stringRegexPlainProperty:
+          format: regex
+          type: string
+        stringRegexRequiredProperty:
+          format: regex
+          type: string
+          pattern: "[a-z]+"
+        stringRegexMinLengthProperty:
+          format: regex
+          type: string
+          pattern: "[a-z]+"
+          minLength: 3
+        stringRegexMaxLengthProperty:
+          format: regex
+          type: string
+          pattern: "[a-z]+"
+          maxLength: 7
+        stringRegexMinLengthMaxLengthProperty:
+          format: regex
+          type: string
+          pattern: "[a-z]+"
+          minLength: 3
+          maxLength: 7
+        stringRegexRequiredMinLengthMaxLengthProperty:
+          format: regex
+          type: string
+          pattern: "[a-z]+"
+          minLength: 3
+          maxLength: 7
+        arrayStringPlainProperty:
+          type: array
+          items:
+            type: string
+        arrayStringRequiredProperty:
+          type: array
+          items:
+            type: string
+        arrayStringMinItemsProperty:
+          minItems: 3
+          type: array
+          items:
+            type: string
+        arrayStringMaxItemsProperty:
+          maxItems: 7
+          type: array
+          items:
+            type: string
+        arrayStringMinItemsMaxItemsProperty:
+          maxItems: 7
+          minItems: 3
+          type: array
+          items:
+            type: string
+        arrayStringRequiredMinItemsMaxItemsProperty:
+          maxItems: 7
+          minItems: 3
+          type: array
+          items:
+            type: string
+        arrayObjectPlainProperty:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationSubRequest'
+        arrayObjectRequiredProperty:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationSubRequest'
+        arrayObjectMinItemsProperty:
+          minItems: 3
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationSubRequest'
+        arrayObjectMaxItemsProperty:
+          maxItems: 7
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationSubRequest'
+        arrayObjectMinItemsMaxItemsProperty:
+          maxItems: 7
+          minItems: 3
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationSubRequest'
+        arrayObjectRequiredMinItemsMaxItemsProperty:
+          maxItems: 7
+          minItems: 3
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationSubRequest'
+        arrayStringUniqueItemsPlainProperty:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        arrayStringUniqueItemsRequiredProperty:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        arrayStringUniqueItemsMinItemsProperty:
+          minItems: 3
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        arrayStringUniqueItemsMaxItemsProperty:
+          maxItems: 7
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        arrayStringUniqueItemsMinItemsMaxItemsProperty:
+          maxItems: 7
+          minItems: 3
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        arrayStringUniqueItemsRequiredMinItemsMaxItemsProperty:
+          maxItems: 7
+          minItems: 3
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        arrayObjectUniqueItemsPlainProperty:
+          uniqueItems: true
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationSubRequest'
+        arrayObjectUniqueItemsRequiredProperty:
+          uniqueItems: true
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationSubRequest'
+        arrayObjectUniqueItemsMinItemsProperty:
+          minItems: 3
+          uniqueItems: true
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationSubRequest'
+        arrayObjectUniqueItemsMaxItemsProperty:
+          maxItems: 7
+          uniqueItems: true
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationSubRequest'
+        arrayObjectUniqueItemsMinItemsMaxItemsProperty:
+          maxItems: 7
+          minItems: 3
+          uniqueItems: true
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationSubRequest'
+        arrayObjectUniqueItemsRequiredMinItemsMaxItemsProperty:
+          maxItems: 7
+          minItems: 3
+          uniqueItems: true
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationSubRequest'
+        objectPlainProperty:
+          $ref: '#/components/schemas/ValidationSubRequest'
+        objectRequiredProperty:
+          $ref: '#/components/schemas/ValidationSubRequest'
+        enumPlainProperty:
+          type: string
+          enum:
+            - active
+            - inactive
+        enumRequiredProperty:
+          type: string
+          enum:
+            - active
+            - inactive
+    ValidationResponse:
+      type: object
+      properties:
+        message:
+          type: string
+    ValidationSubRequest:
+      required:
+      - name
+      type: object
+      properties:
+        name:
+          type: string


### PR DESCRIPTION
https://github.com/nablarch-development-standards/nablarch-development-standards-tools/pull/21 の内容を新規リポジトリに移植したもの。

## 変更内容

Nablarch JAX-RS向けのOpenAPI GeneratorのカスタムGeneratorを実装します。

以下の方針で実装しています。

- ベースはOpenAPI Generator 7.10.0
- OpenAPI GeneratorのJAX-RS（サーバ側）の系譜として実装
  - 基底とする抽象クラスが同じ
- JAX-RS向けの各種Generatorのうち、考え方としては[jaxrs-spec](https://openapi-generator.tech/docs/generators/jaxrs-spec/)をベースにしている
  - ソースコードの生成に使っているMustacheテンプレートはjaxrs-specからカスタマイズして利用
- 生成するコードはApiインターフェース、モデルクラスと生成を抑制できないサポートファイル3種（`.openapi-generator-ignore`、`.openapi-generator/FILES`、`.openapi-generator/VERSION`）のみとする
- 使用しないオプションも基本的には無効化
  - 解説書には明示的にサポートするオプションのみ記載予定
- デフォルトではリクエストは`application/json`と`multipart/form-data`、レスポンスは`application/json`をメディアタイプとして受け付ける
  - オプションで指定可能
- マルチパートやファイルダウンロード以外のパターンで`type: string`、`format: binary`を指定すると、例外をスローする
- もとのNablarch JAX-RSのFormと同様の振る舞いができるように、プリミティブ型のデータ型をすべて`String`にするオプションをサポート

テストケースは、

- Generatorのセットアップ
- Generatorによるコード生成
- 生成されたコードが想定と一致するか、Javaの構文として誤っていないか、内容が想定どおりか（期待値ファイルを用意して比較）
  - 期待値は`src/test/resources/openapi-3_0/[テストクラス名]/[テストメソッド名]/expected`配下へ配置
- テストケースによっては、さらに正規表現で内容確認

という形で実装しています。

サポートするデータ型やオプション、Bean Validationの生成結果などはドキュメントにまとめて解説しています。

## 補足

Nablarchのparentを継承するのをやめるかどうか迷いましたが、Mavenセントラルへのデプロイ等、CIなどで他のモジュールと同じように扱えた方がいいだろうと思って結局parentを継承したままにしました。  
※sql-executorのparentがNablarchになっているのも同じ理由だと思います