### PR TITLE
LICENSEファイルをリネームし、内容も他のリポジトリと統一

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -178,7 +178,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
+      boilerplate notice, with the fields enclosed by brackets "{}"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright {yyyy} {name of copyright owner}
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
このリポジトリの`LICENSE`はGitHubリポジトリ作成時のテンプレートをそのまま使っていましたが、他のリポジトリとファイル名および内容が異なっていたので統一しました。